### PR TITLE
Apply map tile settings everywhere

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -146,17 +146,11 @@
         const tilesUrl = window.userSettings.tiles.service;
         const tilesAttribution = window.userSettings.tiles.attribution;
 
-        if (window.userSettings.preferColoredMap) {
-            L.tileLayer(tilesUrl, {
-                maxZoom: 19,
-                attribution:  tilesAttribution
-            }).addTo(map);
-        } else {
-            L.tileLayer.grayscale(tilesUrl, {
-                maxZoom: 19,
-                attribution: tilesAttribution
-            }).addTo(map);
-        }
+        const tileLayer = window.userSettings.preferColoredMap ? L.tileLayer : L.tileLayer.greyscale;
+        tileLayer(tilesUrl, {
+            maxZoom: 19,
+            attribution:  tilesAttribution
+        }).addTo(map);
         L.control.attribution({position: 'topright'}).addAttribution(tilesAttribution)
             .addTo(map)
 

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -164,7 +164,8 @@
                 const tilesUrl = window.userSettings.tiles.service;
                 const tilesAttribution = window.userSettings.tiles.attribution;
 
-                L.tileLayer.grayscale(tilesUrl, {
+                const tileLayer = window.userSettings.preferColoredMap ? L.tileLayer : L.tileLayer.greyscale;
+                tileLayer(tilesUrl, {
                     maxZoom: 19,
                     attribution: tilesAttribution
                 }).addTo(placeMap);

--- a/src/main/resources/templates/statistics.html
+++ b/src/main/resources/templates/statistics.html
@@ -61,7 +61,11 @@
                 keyboard: false
             });
 
-            L.tileLayer.grayscale('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            const tilesUrl = window.userSettings.tiles.service;
+            const tilesAttribution = window.userSettings.tiles.attribution;
+
+            const tileLayer = window.userSettings.preferColoredMap ? L.tileLayer : L.tileLayer.greyscale;
+            tileLayer(tilesUrl, {
                 attribution: ''
             }).addTo(map);
 


### PR DESCRIPTION
This syncs up the main, statistics and settings views to all honour custom map tiles and attribution, as well as the colour setting.

Currently statistics doesn't follow these settings and has a baked-in URL, while settings uses the custom map tiles but in greyscale.