### PR TITLE
Update .gitignore with docker-compose override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ replay_pid*
 
 *secrets.properties
 *oidc.properties
+
+# Local docker-compose override
+docker-compose.override.yml


### PR DESCRIPTION
I have the repo cloned on my machine and I need to make som edits to the docker-compose file and there is no place for me to keep my local edits when pulling changes. I propose this solution the problem. 

https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/