### PR TITLE
Handle absent home block in memory generation

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/service/MemoryBlockGenerationService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/MemoryBlockGenerationService.java
@@ -240,9 +240,10 @@ public class MemoryBlockGenerationService {
             }
 
 
-            MemoryClusterBlock clusterBlock = convertToTripCluster(tripsFromAccommodation, "Journey to " + home.get().getPlace().getCity());
-
-            blockParts.add(clusterBlock);
+            if (home.isPresent()) {
+                MemoryClusterBlock clusterBlock = convertToTripCluster(tripsFromAccommodation, "Journey to " + home.get().getPlace().getCity());
+                blockParts.add(clusterBlock);
+            }
         }
 
         log.info("Generated {} memory block parts", blockParts.size());


### PR DESCRIPTION
Otherwise, this might trigger `Error creating your memory: No value present` due to the `java.util.NoSuchElementException: No value present` exception on `home.get()`.