### PR TITLE
Extend bounds to the latest location in case no segments have been returned

### DIFF
--- a/src/main/resources/static/js/raw-location-loader.js
+++ b/src/main/resources/static/js/raw-location-loader.js
@@ -223,6 +223,11 @@ class RawLocationLoader {
             }
         }
 
+        // Also extend the bounds to the latest location in case no segments have been returned
+        if (rawPointsData.latest) {
+            bounds.extend([rawPointsData.latest.latitude, rawPointsData.latest.longitude])
+        }
+
         // Add avatar marker for the latest point if in auto-update mode and today is selected
         if (autoUpdateMode && this.isSelectedDateToday() && rawPointsData.latest) {
             const latestPoint = rawPointsData.latest;


### PR DESCRIPTION
Fixes #417