### PR TITLE
feat(#526): add stay detection queue stats

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/service/processing/ProcessingPipelineTrigger.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/processing/ProcessingPipelineTrigger.java
@@ -108,4 +108,7 @@ public class ProcessingPipelineTrigger {
         return executorService.getQueue().isEmpty() &&
                executorService.getActiveCount() == 0;
     }
+    public int getPendingCount() {
+        return executorService.getActiveCount() + executorService.getQueue().size();
+    }
 }


### PR DESCRIPTION
- Integrated `STAY_DETECTION_QUEUE` in `QueueStatsService`
- Added `getPendingCount` method in `ProcessingPipelineTrigger`
- Updated processing history for stay detection queue stats tracking