### PR TITLE
fix(#540): remove redundant bounds extension for latest location

### DIFF
--- a/src/main/resources/static/js/raw-location-loader.js
+++ b/src/main/resources/static/js/raw-location-loader.js
@@ -240,11 +240,6 @@ class RawLocationLoader {
             }
         }
 
-        // Also extend the bounds to the latest location in case no segments have been returned
-        if (rawPointsData.latest) {
-            bounds.extend([rawPointsData.latest.latitude, rawPointsData.latest.longitude])
-        }
-
         // Add avatar marker for the latest point if in auto-update mode and today is selected
         if (autoUpdateMode && this.isSelectedDateToday() && rawPointsData.latest) {
             const latestPoint = rawPointsData.latest;

--- a/src/main/resources/templates/memories/fragments.html
+++ b/src/main/resources/templates/memories/fragments.html
@@ -402,8 +402,6 @@
 
                 // Load location data for the memory date range without bounds filtering
                 rawLocationLoader.loadForDateRange(
-                    null,
-                    null,
                     false, // autoUpdateMode
                     false  // withBounds - don't filter by current map bounds
                 );


### PR DESCRIPTION
- Removed unused code that extended map bounds to the latest location.
- Cleaned up unnecessary parameters in location loading for date range.