### PR TITLE
fix(tests): ensure consistent test behavior and improve reliability i…

### DIFF
--- a/e2e/tests/visit-sensitivity.spec.js
+++ b/e2e/tests/visit-sensitivity.spec.js
@@ -33,17 +33,17 @@ test.describe('Settings - Visit Sensitivity Tests', () => {
     test('should not duplicate edit form', async ({page}) => {
         await page.locator('#nav-settings').click();
         await page.getByRole('link', {name: 'Visit Sensitivity'}).click();
-        await page.getByRole('button', {name: 'Edit'}).click();
+        await page.getByRole('button', {name: 'Edit'}).first().click();
         await expect(page.locator('#edit-form')).toBeVisible();
         await page.getByRole('button', {name: 'Simple'}).click();
-        await page.getByRole('button', {name: 'Edit'}).click();
+        await page.getByRole('button', {name: 'Edit'}).first().click();
         await expect(page.locator('#edit-form')).toBeVisible(); //this will fail if the edit form is duplicated
     });
 
     test('should display simple edit form', async ({page}) => {
         await page.locator('#nav-settings').click();
         await page.getByRole('link', {name: 'Visit Sensitivity'}).click();
-        await page.getByRole('button', {name: 'Edit'}).click();
+        await page.getByRole('button', {name: 'Edit'}).first().click();
         await expect(page.locator('#edit-form')).toBeVisible();
         await page.getByRole('button', {name: 'Simple'}).click();
         await expect(page.locator('#edit-form')).toBeVisible();
@@ -52,7 +52,7 @@ test.describe('Settings - Visit Sensitivity Tests', () => {
     test('should display advanced edit form', async ({page}) => {
         await page.locator('#nav-settings').click();
         await page.getByRole('link', {name: 'Visit Sensitivity'}).click();
-        await page.getByRole('button', {name: 'Edit'}).click();
+        await page.getByRole('button', {name: 'Edit'}).first().click();
         await expect(page.locator('#edit-form')).toBeVisible();
         await page.getByRole('button', {name: 'Advanced'}).click();
         await expect(page.locator('#edit-form')).toBeVisible();
@@ -62,7 +62,7 @@ test.describe('Settings - Visit Sensitivity Tests', () => {
     test('should display recalculation advise', async ({page}) => {
         await page.locator('#nav-settings').click();
         await page.getByRole('link', {name: 'Visit Sensitivity'}).click();
-        await page.getByRole('button', {name: 'Edit'}).click();
+        await page.getByRole('button', {name: 'Edit'}).first().click();
         await expect(page.locator('#edit-form')).toBeVisible();
         await page.getByRole('button', {name: 'Advanced'}).click();
         await expect(page.locator('#edit-form')).toBeVisible();

--- a/src/test/java/com/dedicatedcode/reitti/service/importer/GoogleAndroidTimelineImporterTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/importer/GoogleAndroidTimelineImporterTest.java
@@ -11,13 +11,16 @@ import com.dedicatedcode.reitti.service.VisitDetectionParametersService;
 import com.dedicatedcode.reitti.service.processing.LocationDataIngestPipeline;
 import com.dedicatedcode.reitti.service.processing.ProcessingPipelineTrigger;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -43,9 +46,8 @@ class GoogleAndroidTimelineImporterTest {
         assertTrue(result.containsKey("success"));
         assertTrue((Boolean) result.get("success"));
 
-        // Create a spy to retrieve all LocationDataEvents pushed into RabbitMQ
         ArgumentCaptor<List<LocationPoint>> eventCaptor = ArgumentCaptor.forClass(List.class);
-        verify(mock, times(1)).processLocationData(eq("test"), eventCaptor.capture());
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> verify(mock, times(1)).processLocationData(eq("test"), eventCaptor.capture()));
 
         List<List<LocationPoint>> capturedEvents = eventCaptor.getAllValues();
         assertEquals(1, capturedEvents.size());

--- a/src/test/java/com/dedicatedcode/reitti/service/importer/GoogleIOSTimelineImporterTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/importer/GoogleIOSTimelineImporterTest.java
@@ -17,7 +17,9 @@ import org.mockito.ArgumentCaptor;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -45,7 +47,7 @@ class GoogleIOSTimelineImporterTest {
 
         // Create a spy to retrieve all LocationDataEvents pushed into RabbitMQ
         ArgumentCaptor<List<LocationPoint>> eventCaptor = ArgumentCaptor.forClass(List.class);
-        verify(mock, times(1)).processLocationData(eq("test"), eventCaptor.capture());
+        await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> verify(mock, times(1)).processLocationData(eq("test"), eventCaptor.capture()));
 
         List<List<LocationPoint>> capturedEvents = eventCaptor.getAllValues();
         assertEquals(1, capturedEvents.size());


### PR DESCRIPTION
…n `fix-tests`

- Use Awaitility for async `verify` logic in unit tests
- Fix issue with duplicate form checks by targeting first `Edit` button