### PR TITLE
fix(#491): add spinners for geocoding actions and adjust padding

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -527,8 +527,8 @@ tr:hover {
     font-family: var(--serif-font);
     line-height: 1.5;
     font-weight: 400;
-    padding-top: 48px;
-    padding-bottom: 110px;
+    padding-top: 64px;
+    padding-bottom: 140px;
     transition: opacity 0.3s ease;
 }
 

--- a/src/main/resources/templates/settings/geocode-services.html
+++ b/src/main/resources/templates/settings/geocode-services.html
@@ -141,8 +141,10 @@
                                 hx-target="#geocode-services"
                                 hx-swap="innerHTML"
                                 th:attr="hx-confirm=#{geocoding.run.confirm}"
-                                th:text="#{geocoding.run.button}">
-                            Start Geocoding
+                                hx-indicator="#run-geocode-spinner">
+                            <span class="button-text" th:text="#{geocoding.run.button}">Start Geocoding</span>
+                            <span id="run-geocode-spinner" class="htmx-indicator"><i class="lni lni-is-spinning lni-spinner-2-sacle"></i></span>
+
                         </button>
                     </div>
                     <div class="action-card">
@@ -157,8 +159,9 @@
                                 hx-target="#geocode-services"
                                 hx-swap="innerHTML"
                                 th:attr="hx-confirm=#{geocoding.clear.confirm}"
-                                th:text="#{geocoding.clear.button}">
-                            Clear and Re-geocode
+                                hx-indicator="#clear-re-geocode-spinner">
+                            <span class="button-text" th:text="#{geocoding.clear.button}">Clear and Re-geocode</span>
+                            <span id="clear-re-geocode-spinner" class="htmx-indicator"><i class="lni lni-is-spinning lni-spinner-2-sacle"></i></span>
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
- Add loading spinners for "Start Geocoding" and "Clear and Re-geocode" buttons
- Update top and bottom padding in `main.css` for improved layout