### PR TITLE
fix(604): handle HTMX authentication errors with custom entry point

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/config/HtmxAuthenticationEntryPoint.java
+++ b/src/main/java/com/dedicatedcode/reitti/config/HtmxAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package com.dedicatedcode.reitti.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class HtmxAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        // Check if the request is coming from HTMX
+        if ("true".equals(request.getHeader("HX-Request"))) {
+            // Tell HTMX to redirect the whole window to the login page
+            response.setHeader("HX-Redirect", "/login");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        } else {
+            // Standard behavior for non-HTMX requests (regular 302 redirect)
+            response.sendRedirect("/login");
+        }
+    }
+}

--- a/src/main/java/com/dedicatedcode/reitti/config/SecurityConfig.java
+++ b/src/main/java/com/dedicatedcode/reitti/config/SecurityConfig.java
@@ -34,6 +34,9 @@ public class SecurityConfig {
     @Autowired
     private SetupFilter setupFilter;
 
+    @Autowired
+    private HtmxAuthenticationEntryPoint authenticationEntryPoint;
+
     @Autowired(required = false)
     private LogoutSuccessHandler oidcLogoutSuccessHandler;
 
@@ -77,6 +80,7 @@ public class SecurityConfig {
                         .rememberMeParameter("remember-me")
                         .useSecureCookie(false)
                 )
+                .exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint(authenticationEntryPoint))
                 .logout(logout -> {
                     if (oidcLogoutSuccessHandler != null) {
                         logout.logoutSuccessHandler(oidcLogoutSuccessHandler);


### PR DESCRIPTION
- Add `HtmxAuthenticationEntryPoint` to handle HTMX-specific authentication failures
- Update `SecurityConfig` to use the custom authentication entry point