### PR TITLE
fix(624): correct body field for GPSLogger integration

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/controller/settings/IntegrationsSettingsController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/settings/IntegrationsSettingsController.java
@@ -148,7 +148,7 @@ public class IntegrationsSettingsController {
         String url = serverUrl + "/api/v1/ingest/owntracks?token=" + token;
         String properties = "log_customurl_url=" + url + "\n" +
                             "log_customurl_method=POST\n" +
-                            "log_customurl_headers={\"_type\" : \"location\",\"t\": \"u\",\"acc\": \"%ACC\",\"alt\": \"%ALT\",\"batt\": \"%BATT\",\"bs\": \"%ISCHARGING\",\"lat\": \"%LAT\",\"lon\": \"%LON\",\"tst\": \"%TIMESTAMP\",\"vel\": \"%SPD\"}\n" +
+                            "log_customurl_body={\"_type\" : \"location\",\"t\": \"u\",\"acc\": \"%ACC\",\"alt\": \"%ALT\",\"batt\": \"%BATT\",\"bs\": \"%ISCHARGING\",\"lat\": \"%LAT\",\"lon\": \"%LON\",\"tst\": \"%TIMESTAMP\",\"vel\": \"%SPD\"}\n" +
                             "log_customurl_headers=Content-Type: application/json\n" +
                             "autosend_frequency_minutes=60\n" +
                             "accuracy_before_logging=25\n" +


### PR DESCRIPTION
- Fix typo by renaming `log_customurl_headers` to `log_customurl_body`
- Ensure proper configuration for GPSLogger integration