### PR TITLE
feat(628): publish Docker image to GitHub Container Registry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,11 @@ on:
     branches:
       - main
 
+permissions:
+  packages: write
+
 jobs:
-  tagged-release:
+  build-and-publish-develop:
     name: "Release"
     runs-on: "ubuntu-latest"
 
@@ -32,6 +35,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -42,6 +51,7 @@ jobs:
         with:
           images: |
             dedicatedcode/reitti
+            ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=develop,enable={{is_default_branch}}
       - name: Build and push


### PR DESCRIPTION
- Add GitHub Container Registry login to CI workflow
- Update job to build and publish images to both Docker Hub and GHCR