### PR TITLE
fix(667): ensure user with MQTT setup can be deleted

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/repository/MqttIntegrationJdbcService.java
+++ b/src/main/java/com/dedicatedcode/reitti/repository/MqttIntegrationJdbcService.java
@@ -137,6 +137,10 @@ public class MqttIntegrationJdbcService {
         );
     }
 
+    public void deleteForUser(User user) {
+        this.jdbcTemplate.update("DELETE FROM mqtt_integrations WHERE user_id = ?", user.getId());
+    }
+
     private static class MqttIntegrationRowMapper implements RowMapper<MqttIntegration> {
         @Override
         public MqttIntegration mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/src/main/java/com/dedicatedcode/reitti/service/UserService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/UserService.java
@@ -31,6 +31,7 @@ public class UserService {
     private final ProcessedVisitJdbcService processedVisitJdbcService;
     private final GeocodingResponseJdbcService geocodingResponseJdbcService;
     private final ApiTokenJdbcService apiTokenJdbcService;
+    private final MqttIntegrationJdbcService mqttIntegrationJdbcService;
     private final PasswordEncoder passwordEncoder;
 
     public UserService(UserJdbcService userJdbcService,
@@ -42,6 +43,7 @@ public class UserService {
                        ProcessedVisitJdbcService processedVisitJdbcService,
                        GeocodingResponseJdbcService geocodingResponseJdbcService,
                        ApiTokenJdbcService apiTokenJdbcService,
+                       MqttIntegrationJdbcService mqttIntegrationJdbcService,
                        PasswordEncoder passwordEncoder) {
         this.userJdbcService = userJdbcService;
         this.userSettingsJdbcService = userSettingsJdbcService;
@@ -52,6 +54,7 @@ public class UserService {
         this.processedVisitJdbcService = processedVisitJdbcService;
         this.geocodingResponseJdbcService = geocodingResponseJdbcService;
         this.apiTokenJdbcService = apiTokenJdbcService;
+        this.mqttIntegrationJdbcService = mqttIntegrationJdbcService;
         this.passwordEncoder = passwordEncoder;
     }
 
@@ -138,6 +141,7 @@ public class UserService {
         this.rawLocationPointJdbcService.deleteAllForUser(user);
         this.rawLocationPointJdbcService.deleteAllForUser(user);
         this.apiTokenJdbcService.deleteForUser(user);
+        this.mqttIntegrationJdbcService.deleteForUser(user);
         this.userJdbcService.deleteUser(user.getId());
     }
 }

--- a/src/main/resources/db/migration/V78__fix_mqtt_table_colums.sql
+++ b/src/main/resources/db/migration/V78__fix_mqtt_table_colums.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mqtt_integrations ALTER COLUMN username DROP NOT NULL;
+ALTER TABLE mqtt_integrations ALTER COLUMN password DROP NOT NULL;

--- a/src/test/java/com/dedicatedcode/reitti/service/UserServiceTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/UserServiceTest.java
@@ -1,7 +1,6 @@
 package com.dedicatedcode.reitti.service;
 
 import com.dedicatedcode.reitti.IntegrationTest;
-import com.dedicatedcode.reitti.TestingService;
 import com.dedicatedcode.reitti.model.Language;
 import com.dedicatedcode.reitti.model.Role;
 import com.dedicatedcode.reitti.model.TimeDisplayMode;
@@ -10,9 +9,12 @@ import com.dedicatedcode.reitti.model.geo.TransportModeConfig;
 import com.dedicatedcode.reitti.model.processing.DetectionParameter;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.model.security.UserSettings;
+import com.dedicatedcode.reitti.repository.MqttIntegrationJdbcService;
+import com.dedicatedcode.reitti.repository.TransportModeJdbcService;
 import com.dedicatedcode.reitti.repository.UserSettingsJdbcService;
 import com.dedicatedcode.reitti.repository.VisitDetectionParametersJdbcService;
-import com.dedicatedcode.reitti.repository.TransportModeJdbcService;
+import com.dedicatedcode.reitti.service.integration.mqtt.MqttIntegration;
+import com.dedicatedcode.reitti.service.integration.mqtt.PayloadType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -28,9 +30,6 @@ class UserServiceTest {
     private UserService userService;
 
     @Autowired
-    private TestingService testingService;
-
-    @Autowired
     private UserSettingsJdbcService userSettingsJdbcService;
 
     @Autowired
@@ -38,6 +37,9 @@ class UserServiceTest {
 
     @Autowired
     private TransportModeJdbcService transportModeJdbcService;
+
+    @Autowired
+    private MqttIntegrationJdbcService mqttIntegrationJdbcService;
 
     @Test
     void shouldCreateUserWithExternalIdAndDefaultSettings() {
@@ -149,6 +151,12 @@ class UserServiceTest {
         List<TransportModeConfig> transportConfigs = transportModeJdbcService.getTransportModeConfigs(user);
         assertThat(detectionParams).isNotEmpty();
         assertThat(transportConfigs).isNotEmpty();
+
+        this.mqttIntegrationJdbcService.save(user, MqttIntegration.empty()
+                .withHost("localhost")
+                .withIdentifier("identifier")
+                .withTopic( "topic")
+                .withPayloadType(PayloadType.OWNTRACKS));
 
         // When
         userService.deleteUser(user);


### PR DESCRIPTION
- Add `deleteForUser` to `MqttIntegrationJdbcService`
- Update `UserService` to delete MQTT data when a user is deleted
- Make `username` and `password` columns nullable in `mqtt_integrations` table
- Add unit test to verify user deletion handles MQTT setup