### PR TITLE
feat: improve statistics page on mobile devices

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -130,6 +130,15 @@ body {
     font-size: 1.4rem;
 }
 
+.statistics-page .navbar {
+    margin-left: 0;
+}
+
+.statistics-page .navigation-container {
+    background-color: rgba(59, 59, 59, 0.68);
+    backdrop-filter: blur(10px);
+}
+
 .navbar i {
     font-size: 1.4rem;
 }
@@ -2643,4 +2652,20 @@ button:disabled {
 }
 .timeband-item.selected:hover::before {
     opacity: 1;
+}
+
+@media (max-width: 900px) {
+    .statistics-page .timeline {
+        width: 24%;
+    }
+
+    .statistics-page .navigation-container {
+        width: 100%;
+    }
+
+    .statistics-page .statistics-content {
+        margin-left: 22%;
+        padding: 72px 1rem 1rem;
+        z-index: 1;
+    }
 }

--- a/src/main/resources/templates/statistics.html
+++ b/src/main/resources/templates/statistics.html
@@ -15,7 +15,7 @@
     <script th:src="@{/js/leaflet.js}"></script>
     <script th:src="@{/js/TileLayer.Grayscale.js}"></script>
 </head>
-<body class="background-dark">
+<body class="background-dark statistics-page">
 <div id="statistics-panel"></div>
 <div class="navigation-container" th:replace="~{fragments/main-navigation :: main-navigation('statistics')}"></div>
 


### PR DESCRIPTION
Hey there,

sorry for just opening a PR out of nowhere. I know reitti isn't a mobile-first project, nevertheless I was wondering if it's worth merging a small tweak that improves the situation on mobile by make sure the side-bar timeline for the statistics page dynamically shrinks to a smaller amount, while also keeping consistency with the top navigation bar between the map view and statistics page.

<img width="498" height="643" alt="Screenshot 2026-01-26 at 12 48 36" src="https://github.com/user-attachments/assets/2c70872e-6d4b-4e79-8391-1b00361245bb" />
