### PR TITLE
feat(731): add "Align North" button and improve UI interactions

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -1548,6 +1548,7 @@ body.auto-update-mode .today-fab {
     .navigation-container {
         background-color: rgba(59, 59, 59, 0.68);
         backdrop-filter: blur(10px);
+        user-select: none;
 
     }
     .navigation-container,
@@ -1727,6 +1728,7 @@ body.datepicker-hidden .fab-container {
     visibility: hidden;
     transition: opacity 0.2s ease, visibility 0.2s ease;
     z-index: 1000;
+    width: 8rem;
 }
 
 .map-controls-section:hover .map-controls {

--- a/src/main/resources/static/js/map-renderer.js
+++ b/src/main/resources/static/js/map-renderer.js
@@ -541,4 +541,12 @@ class MapRenderer {
             pitch: 45
         });
     }
+
+    setBearing(number) {
+        this.map.easeTo({
+            bearing: number,
+            duration: 500, // Mapbox uses 'duration' in ms
+            essential: true
+        });
+    }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -114,7 +114,8 @@
                 <span>3D</span>
             </button>
             <button type="button" class="btn map-control-btn" id="compass-btn" title="Reset North Up">
-                <i class="lni lni-compass"></i>
+                <i class="lni lni-location-arrow-right"></i>
+                <span>North up</span>
             </button>
         </div>
     </div>
@@ -1268,7 +1269,6 @@
     }
     
     function resetNorthUp() {
-        // Reset bearing to 0 (north up)
         mapRenderer.setBearing(0);
     }
 


### PR DESCRIPTION
- Added "North up" button with updated icon and label in the UI
- Introduced `setBearing` method to reset map bearing
- Updated map controls CSS with non-selectable navigation container and adjusted width
- Enhanced user experience features such as button text visibility