### PR TITLE
feat(769): fallback to OIDC subject when creating username

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/config/CustomOidcUserService.java
+++ b/src/main/java/com/dedicatedcode/reitti/config/CustomOidcUserService.java
@@ -60,8 +60,12 @@ public class CustomOidcUserService extends OidcUserService {
         if (preferredUsername == null) {
             preferredUsername = oidcUser.getEmail();
         }
-        if (preferredUsername == null) {
+        if (preferredUsername == null && oidcUser.getFamilyName() != null && oidcUser.getGivenName() != null){
             preferredUsername = oidcUser.getGivenName().toLowerCase() + "." + oidcUser.getFamilyName().toLowerCase();
+        }
+        if (preferredUsername == null) {
+            log.warn("No preferred username found for user: {}. Will fallback to OIDC subject", oidcUser);
+            preferredUsername = userRequest.getIdToken().getSubject();
         }
         String oidcUserId = userRequest.getIdToken().getIssuer().toString() + ":" + userRequest.getIdToken().getSubject();
 

--- a/src/main/java/com/dedicatedcode/reitti/service/processing/TransportModeService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/processing/TransportModeService.java
@@ -40,14 +40,14 @@ public class TransportModeService {
 
     public TransportMode segmentAndClassifyTrip(List<RawLocationPoint> points, List<TransportModeConfig> configs) {
         List<TripSegment> segments = new ArrayList<>();
-        List<Double> speeds = calculateSpeeds(points); // Speeds between points
+        List<Double> speeds = calculateSpeeds(points);
 
         List<RawLocationPoint> currentSegmentPoints = new ArrayList<>();
         currentSegmentPoints.add(points.getFirst());
 
         for (int i = 1; i < points.size(); i++) {
-            double prevSpeed = (i > 1) ? speeds.get(i - 2) : 0; // Speed to previous point
-            double currSpeed = speeds.get(i - 1); // Speed from current to next
+            double prevSpeed = (i > 1) ? speeds.get(i - 2) : 0;
+            double currSpeed = speeds.get(i - 1);
 
             if (prevSpeed > 0 && Math.abs(currSpeed - prevSpeed) / prevSpeed > 0.5) {
                 TransportMode mode = classifySegment(currentSegmentPoints, configs);


### PR DESCRIPTION
- Add OIDC subject as a fallback when no username can be generated
- Improve debug logging for missing preferred username
- Clean up redundant comments in `TransportModeService`