### PR TITLE
fix(788): resolve Redis container startup issues

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/config/AppConfig.java
+++ b/src/main/java/com/dedicatedcode/reitti/config/AppConfig.java
@@ -2,15 +2,22 @@ package com.dedicatedcode.reitti.config;
 
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.data.redis.cache.BatchStrategies;
-import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
 import org.springframework.data.redis.cache.RedisCacheWriter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 @EnableCaching
@@ -34,6 +41,26 @@ public class AppConfig {
                             BatchStrategies.scan(1000)
                     )
             );
+        };
+    }
+    @Bean
+    public static BeanFactoryPostProcessor rqueuePropertyOverride() {
+        return beanFactory -> {
+            ConfigurableEnvironment env = (ConfigurableEnvironment) beanFactory.getBean(Environment.class);
+
+            // 1. Get the prefix (default to empty string if not set)
+            String prefix = env.getProperty("spring.cache.redis.key-prefix", "");
+
+            // 2. If a prefix exists, calculate the new version key
+            if (!prefix.isEmpty()) {
+                String newVersionKey = prefix + "__rq::version";
+
+                // 3. Inject this back into the environment properties
+                Map<String, Object> map = new HashMap<>();
+                map.put("rqueue.version.key", newVersionKey);
+
+                env.getPropertySources().addFirst(new MapPropertySource("rqueueOverride", map));
+            }
         };
     }
 }

--- a/src/main/java/com/dedicatedcode/reitti/config/RQueueCustomMessageConverter.java
+++ b/src/main/java/com/dedicatedcode/reitti/config/RQueueCustomMessageConverter.java
@@ -6,6 +6,7 @@ import com.github.sonus21.rqueue.converter.GenericMessageConverter;
 import com.github.sonus21.rqueue.converter.MessageConverterProvider;
 import org.springframework.messaging.converter.MessageConverter;
 
+@SuppressWarnings("unused") //is set from the application.properties
 public class RQueueCustomMessageConverter implements MessageConverterProvider {
     @Override
     public MessageConverter getConverter() {

--- a/src/main/java/com/dedicatedcode/reitti/service/processing/GeoPointAnomalyFilter.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/processing/GeoPointAnomalyFilter.java
@@ -96,8 +96,7 @@ public class GeoPointAnomalyFilter {
             }
         }
 
-        logger.debug("Filtered {} points due to excessive speed (median: {} m/s, threshold: {} m/s)",
-                     anomalies.size(), medianSpeed, threshold);
+        logger.debug("Filtered {} points due to excessive speed (median: {} m/s, threshold: {} m/s)", anomalies.size(), medianSpeed, threshold);
         return anomalies;
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,6 +45,7 @@ spring.servlet.multipart.max-request-size=5GB
 server.tomcat.max-part-count=100
 
 # disable rqueue persistent job storage
+rqueue.web.enable=false
 rqueue.job.enabled=false
 rqueue.message.durability.in-terminal-state=0
 rqueue.key.prefix=${spring.cache.redis.key-prefix}


### PR DESCRIPTION
- Added `rqueuePropertyOverride` to inject dynamic Redis key prefixes.
- Suppressed unused warnings in `RQueueCustomMessageConverter`.
- Disabled Rqueue web UI via application properties.