### PR TITLE
Exclude ignored points from visit detection clustering to support high-frequency tracking (e.g. Overland)

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/repository/PreviewRawLocationPointJdbcService.java
+++ b/src/main/java/com/dedicatedcode/reitti/repository/PreviewRawLocationPointJdbcService.java
@@ -63,7 +63,7 @@ public class PreviewRawLocationPointJdbcService {
         String sql = "SELECT rlp.id, rlp.accuracy_meters, rlp.elevation_meters, rlp.timestamp, rlp.user_id, ST_AsText(rlp.geom) as geom, rlp.processed, rlp.synthetic, rlp.ignored, rlp.version , " +
                 "ST_ClusterDBSCAN(rlp.geom, ?, ?) over () AS cluster_id " +
                 "FROM preview_raw_location_points rlp " +
-                "WHERE rlp.user_id = ? AND rlp.timestamp BETWEEN ? AND ? AND preview_id = ?";
+                "WHERE rlp.user_id = ? AND rlp.timestamp BETWEEN ? AND ? AND preview_id = ? AND rlp.ignored = false";
 
         return jdbcTemplate.query(sql, (rs, _) -> {
 

--- a/src/main/java/com/dedicatedcode/reitti/repository/RawLocationPointJdbcService.java
+++ b/src/main/java/com/dedicatedcode/reitti/repository/RawLocationPointJdbcService.java
@@ -202,7 +202,7 @@ public class RawLocationPointJdbcService {
         String sql = "SELECT rlp.id, rlp.accuracy_meters, rlp.elevation_meters, rlp.timestamp, rlp.user_id, ST_AsText(rlp.geom) as geom, rlp.processed, rlp.synthetic, rlp.invalid, rlp.ignored, rlp.version , " +
                 "ST_ClusterDBSCAN(rlp.geom, ?, ?) over () AS cluster_id " +
                 "FROM raw_location_points rlp " +
-                "WHERE rlp.user_id = ? AND rlp.timestamp >= ? AND rlp.timestamp < ?";
+                "WHERE rlp.user_id = ? AND rlp.timestamp >= ? AND rlp.timestamp < ? AND rlp.ignored = false AND rlp.invalid = false";
 
         return jdbcTemplate.query(sql, (rs, rowNum) -> {
 


### PR DESCRIPTION
First of all, thank you for providing such an amazing and useful project.

### Motivation

I've been using Overland for location tracking on iOS. I prefer it over OwnTracks because it feels more native to iOS and supports batch sending.

However, when I set the "Desired Accuracy" to 10 meters, iOS sometimes reports locations to the app more frequently than once per second. While Overland limits this to one update per second, this frequency still seems to be too high for Reitti to handle cleanly. It causes issues such as the Visit Detection feature failing to create distinct Visits during movements and instead clumping an entire walk into one large continuous Visit. (While this can be mitigated by tweaking parameters, issues still remain, such as Trips not being generated correctly.)

As you mentioned in [#195 (comment)](https://github.com/dedicatedcode/reitti/issues/195#issuecomment-3268647006): *"1 second seems to be too much at the moment."* This PR is an attempt to address this issue.

### Changes

Since Reitti already has the `LocationDataDensityNormalizer` implemented, I thought we could utilize it for this case as well.

To resolve the clustering issue, I updated the SQL queries used in Visit Detection (`ST_ClusterDBSCAN`) so that it filters out the redundant points that have already been thinned out by the normalizer (by adding `ignored = false AND invalid = false`).

### Results

In my environment, this change seems to work very well. Visits and Trips are now being generated as expected, even with continuous high-density location data.

### Reference: My Specific Settings

For reference, here are my current settings. I haven't done rigorous empirical testing, so there might be better configurations, but this works well for me:

**Reitti**
*Visit Detection*
- Minimum Stay Time: `600` seconds
- Max Merge Time Between Same Stay Points: `1800` seconds

*Visit Merging*
- Search Duration: `48` hours
- Max Merge Time Between Same Visits: `3600` seconds
- Min Distance Between Visits: `200` meters

**Overland (iOS)**
- Continuous Tracking Mode: `Both`
  *(To ensure tracking continues to run reliably in the background.)*
- Desired Accuracy: `10 m`
  *(To save battery while still getting a decently accurate trajectory. I find this to be a good balance for anyone who isn't satisfied with 15- or 30-second interval tracking.)*
- Pause Updates Automatically: `No`
  *(If enabled, the app pauses updates which creates gaps that are too large from the previous point, sometimes resulting in unintentionally long Trips.)*

---

Please let me know if this approach conflicts with the intended design or if any adjustments are needed. Thanks again for open-sourcing this project!