### PR TITLE
fix(806): handle null passwords when local login is disabled

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/config/CustomOidcUserService.java
+++ b/src/main/java/com/dedicatedcode/reitti/config/CustomOidcUserService.java
@@ -96,7 +96,7 @@ public class CustomOidcUserService extends OidcUserService {
                 log.info("Updating username for user with id [{}] from [{}] to [{}]", user.getId(), user.getUsername(), preferredUsername);
                 user = user.withUsername(preferredUsername);
             }
-            if (localLoginDisabled && !user.getPassword().isEmpty()) {
+            if (localLoginDisabled && user.getPassword() != null && !user.getPassword().isEmpty()) {
                 log.info("Reset password for user with id [{}]. Disabling local login.", user.getId());
                 user = user.withPassword("");
             }


### PR DESCRIPTION
- Prevent NullPointerException by adding a null check for passwords