### PR TITLE
fix(810): resolve health check failures by updating BASE_PATH configu…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ EXPOSE 8080
 
 # Add healthcheck
 HEALTHCHECK --interval=5s --timeout=3s --start-period=1s --retries=20 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1
+  CMD sh -c 'wget --no-verbose --tries=1 --spider "http://localhost:8080${BASE_PATH}/actuator/health" || exit 1'
 
 # Install su-exec for proper user switching and wget for healthcheck
 RUN apk add --no-cache su-exec wget attr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,11 @@ services:
     volumes:
      - reitti-data:/data/
     environment:
-      PHOTON_BASE_URL: http://photon:2322
       POSTGIS_USER: reitti
       POSTGIS_PASSWORD: reitti
       POSTGIS_DB: reittidb
       POSTGIS_HOST: postgis
+      BASE_PATH: /reitti
   postgis:
     image: postgis/postgis:17-3.5-alpine
     environment:
@@ -41,22 +41,14 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  photon:
-    image: rtuszik/photon-docker:1.3.0
-    environment:
-      - UPDATE_STRATEGY=PARALLEL
-      - REGION=de #set your main country code here to save space or drop this line to fetch the whole index.
-    volumes:
-      - photon-data:/photon/data
-
   tile-cache:
     image: dedicatedcode/reitti-tile-cache:latest
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1/osm/0/0/0.png"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
       - tile-cache-data:/var/cache/nginx
 volumes:

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -22,7 +22,7 @@ reitti.process-data.schedule=-
 
 reitti.storage.path=data/
 
-#server.servlet.context-path=/reitti
+server.servlet.context-path=/reitti
 
 spring.data.redis.username=reitti
 spring.data.redis.password=reitti


### PR DESCRIPTION
…ration

- Removed unused `photon` service from `docker-compose.yml`
- Updated `BASE_PATH` handling for health checks in `Dockerfile`
- Set `server.servlet.context-path` in `application-dev.properties`
- Adjusted healthcheck intervals and retries for `docker-compose.yml` services