### PR TITLE
feat(860): add manual testing stage in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,3 @@
----
 name: "release"
 
 on:
@@ -6,57 +5,106 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
+
 permissions:
   packages: write
   contents: write
+  issues: write
 
 jobs:
   tagged-release:
     name: "Build Release"
     runs-on: "ubuntu-latest"
-
+    environment: release-gate
     steps:
       - uses: actions/checkout@v4
+      - name: Auto-create verification issue
+        run: |
+          cat > /tmp/release-checklist.md << 'CHECKLIST_EOF'
+          ## Manual Verification Checklist
+          Run the application locally or on a test instance against the `main` branch at commit `${{ github.sha }}`.
+
+          - [ ] Auth: Local login (admin:admin) + session persistence
+          - [ ] Auth: OIDC login, profile sync, logout callback
+          - [ ] Map: Tiles load, fullscreen toggle, custom tile fallback
+          - [ ] Live mode: Incoming points render without page reload
+          - [ ] Timeline: Trips/visits display, duration/distance accurate
+          - [ ] Multi-user: Data isolation confirmed (no cross-leak)
+          - [ ] Import: GPX/GeoJSON triggers queue, status visible in UI
+          - [ ] Geocoding: Failover handled gracefully (no UI freeze)
+          - [ ] i18n/Units: Language & Metric/Imperial switches work
+          - [ ] CI: All PR tests green, no flaky failures in main
+
+          ## Notes & Observations
+          <!-- Add any edge cases, performance notes, or known limitations here -->
+
+          ## Next Steps
+          1. Complete verification against the ${{ github.ref_name }} build
+          2. Check all boxes above
+          3. Approve the paused workflow run: Actions -> Select run -> Review deployments -> Approve
+          4. This issue will auto-close upon successful release
+          CHECKLIST_EOF
+
+          EXISTS=$(gh issue list --label "release-verification" --state open --limit 1 --json number -q '.[0].number // empty')
+          if [ -z "$EXISTS" ]; then
+            gh issue create \
+              --title "Verify ${{ github.ref_name }}" \
+              --label "release-verification" \
+              --body-file /tmp/release-checklist.md \
+              --assignee "$GITHUB_ACTOR"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           java-version: '25'
           distribution: 'temurin'
           cache: maven
+
       - name: Install dependencies for acknowledgments script
         run: |
           sudo apt-get update
           sudo apt-get install -y jq curl
+
       - name: Generate acknowledgments data
         run: |
           chmod +x scripts/generate-acknowledgments.sh
           ./scripts/generate-acknowledgments.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build
         run: mvn verify -DskipTests
+
       - name: Create bundle
         run: mkdir staging && cp target/*.jar staging
+
       - name: Upload packages
         uses: actions/upload-artifact@v4
         with:
           name: Package
           path: staging
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Docker meta for reitti
         id: meta
         uses: docker/metadata-action@v5
@@ -69,6 +117,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-beta') }}
             type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-beta') }}
+
       - name: Build and push reitti image
         uses: docker/build-push-action@v6
         with:
@@ -77,6 +126,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
       - name: Docker meta for tile-cache
         id: meta-tile-cache
         uses: docker/metadata-action@v5
@@ -89,6 +139,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-beta') }}
             type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-beta') }}
+
       - name: Build and push tile-cache image
         uses: docker/build-push-action@v6
         with:
@@ -97,6 +148,15 @@ jobs:
           push: true
           tags: ${{ steps.meta-tile-cache.outputs.tags }}
           labels: ${{ steps.meta-tile-cache.outputs.labels }}
+
+      - name: Close verification issue on success
+        if: success()
+        run: |
+          ISSUE=$(gh issue list --label "release-verification" --state open --limit 1 --json number -q '.[0].number')
+          [ -n "$ISSUE" ] && gh issue close "$ISSUE" --comment "✅ Released via workflow run #${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Release
         uses: softprops/action-gh-release@v2
         if: github.ref_type == 'tag'
@@ -107,5 +167,6 @@ jobs:
           files: |
             staging/*.jar
             LICENSE
+
       - name: Update dependency graph
         uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,57 @@
+## 🚦 Release Gate & Tag Cleanup
+
+This project uses a single-branch flow (`main` → tag → publish). Pushing a version tag triggers a CI workflow that **pauses for manual verification** before building Docker images or publishing assets.
+
+## How to Approve the Release
+
+Once you push a version tag (e.g., `v4.2.0`), the release workflow automatically pauses at the `release-gate` environment and waits for manual verification. Follow these steps to approve and continue the build:
+
+### 1. Complete Manual Verification
+- Run the application locally or on a test instance using Docker Compose
+- Walk through the verification checklist (auth flows, map/tiles, live mode, import pipeline, multi-user isolation, i18n/units, etc.)
+- Update the auto-created GitHub issue titled with the version number with your findings or confirm all checklist items are completed
+- Do not approve until all critical paths are verified
+
+### 2. Approve via GitHub UI (Recommended)
+1. Navigate to **Actions** in your repository
+2. Click the pending workflow run named `release / Build Release` triggered by your tag
+3. In the workflow summary, locate the job that shows `Waiting`
+4. Click **Review deployments** in the top-right corner
+5. Select **Approve and deploy**
+6. Optionally add a comment (e.g., `Checklist verified, all systems nominal.`) and confirm
+7. The workflow will immediately resume from where it paused
+
+### 3. Approve via GitHub CLI (Alternative)
+If you prefer the terminal, you can approve the pending run directly:
+```bash
+# Find the latest waiting run for this repo
+RUN_ID=$(gh run list --status waiting --limit 1 --json databaseId -q '.[0].databaseId')
+
+# Approve it
+gh run approve "$RUN_ID"
+```
+Note: Your GitHub account must be listed as a required reviewer for the `release-gate` environment for CLI approval to succeed.
+
+### What Happens After Approval
+- The workflow resumes, builds the JAR, pushes multi-arch Docker images to Docker Hub and GHCR, and publishes the GitHub Release
+- The verification issue is automatically closed with a success comment linking to the workflow run
+- Check the **Actions** tab to confirm all steps completed successfully
+- You can now share the release notes and notify users
+
+### Environment Management
+- Add or remove approvers: `Settings -> Environments -> release-gate -> Required reviewers`
+- Enable `Prevent self-approval` in the same menu if you require a second maintainer to verify
+- Approvals are tied to the environment, not individual runs, so permissions persist across releases
+
+### What happens if I don't approve?
+- The workflow stays in a `Waiting` state.
+- **The tag is NOT deleted automatically.** Git tags are permanent references.
+- If you decide to abort the release, you must cancel the workflow run and delete the tag manually:
+
+```bash
+# Cancel the pending workflow run via UI or CLI
+gh run cancel <run-id>
+
+# Delete the tag locally & remotely
+git tag -d v4.2.0
+git push origin --delete v4.2.0


### PR DESCRIPTION
- Introduce "release-gate" environment for manual approval
- Add auto-created GitHub issue for verification checklist
- Include steps for Docker image build and publishing after approval
- Automate issue closure post successful release