### PR TITLE
fix(883): adjust map zoom bounds and resolve mobile padding issue

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -230,7 +230,6 @@ header {
     font-family: sans-serif;
     color: var(--color-background-dark-light);
     text-shadow: 0 0 2px var(--color-highlight);
-    padding-right: 180px;
 }
 
 #tooltip::-webkit-scrollbar {
@@ -360,6 +359,11 @@ header {
     .settings-menu-content {
         padding: 12px;
     }
+
+    .loading-overlay {
+        top: 46px;
+    }
+
 }
 /* Elements */
 .btn {

--- a/src/main/resources/static/js/map-renderer.js
+++ b/src/main/resources/static/js/map-renderer.js
@@ -206,7 +206,12 @@ class MapRenderer {
 
     fitMapToBounds(bounds) {
         this.map.stop();
-        this.map.fitBounds(bounds, this.viewConfig.fitConfig);
+        const containerWidth = this.map.getContainer().clientWidth;
+        const config = { ...this.viewConfig.fitConfig };
+        if (containerWidth < 600) {
+            config.padding = { top: 20, bottom: 20, right: 20, left: 20 };
+        }
+        this.map.fitBounds(bounds, config);
     }
 
     flyTo(config) {


### PR DESCRIPTION
- Fix map zoom to properly adjust bounds on small screens with custom padding
- Remove unnecessary padding from tooltip styles
- Adjust loading overlay alignment on mobile