### PR TITLE
feat(900): add configurable radius for reverse geocoding in Photon

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/controller/settings/GeoCodingSettingsController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/settings/GeoCodingSettingsController.java
@@ -111,11 +111,12 @@ public class GeoCodingSettingsController {
                                     @RequestParam(required = false) String apiKey,
                                     @RequestParam(required = false) String lang,
                                     @RequestParam(required = false) Integer limit,
+                                    @RequestParam(required = false) Double radius,
                                     Model model) {
         try {
             double testLat = 48.8584;
             double testLng = 2.2945;
-            GeocodeService tmpService = verifySelection(type, url, apiKey, lang, limit);
+            GeocodeService tmpService = verifySelection(type, url, apiKey, lang, limit, radius);
 
             GeocodeResult result = geocodeServiceManager.test(tmpService, testLat, testLng);
             model.addAttribute("testResult", result);
@@ -125,7 +126,7 @@ public class GeoCodingSettingsController {
         return "settings/fragments/geocoding :: test-result-display";
     }
 
-    private GeocodeService verifySelection(GeocoderType type, String url, String apiKey, String lang, Integer limit) {
+    private GeocodeService verifySelection(GeocoderType type, String url, String apiKey, String lang, Integer limit, Double radius) {
         if (type != GEO_APIFY && (url == null || url.isEmpty())) {
             throw new IllegalArgumentException("Url must not be empty");
         }
@@ -141,6 +142,9 @@ public class GeoCodingSettingsController {
         }
         if (limit != null) {
             params.put("limit", limit.toString());
+        }
+        if (radius != null) {
+            params.put("radius", radius.toString());
         }
         if (apiKey != null && !apiKey.isEmpty()) {
             params.put("apiKey", apiKey);
@@ -159,6 +163,7 @@ public class GeoCodingSettingsController {
                                        @RequestParam(required = false) String apiKey,
                                        @RequestParam(required = false) String language,
                                        @RequestParam(required = false) Integer limit,
+                                       @RequestParam(required = false) Double radius,
                                        @RequestParam int priority,
                                        Model model) {
         try {
@@ -168,6 +173,9 @@ public class GeoCodingSettingsController {
             }
             if (limit != null) {
                 params.put("limit", limit.toString());
+            }
+            if (radius != null) {
+                params.put("radius", radius.toString());
             }
             if (apiKey != null && !apiKey.isEmpty()) {
                 params.put("apiKey", apiKey);

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/GeocodeService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/GeocodeService.java
@@ -82,7 +82,16 @@ public class GeocodeService {
 
     public String getUrlTemplate() {
         return switch (type) {
-            case PHOTON -> this.url + "/reverse?lon={lng}&lat={lat}&limit=10&layer=house&layer=locality&radius=0.03";
+            case PHOTON -> {
+                String urlTemplate = this.url + "/reverse?lon={lng}&lat={lat}&layer=house&layer=locality";
+                if (this.additionalParameters.containsKey("radius")) {
+                    urlTemplate += "&radius=" + this.additionalParameters.get("radius");
+                }
+                if (this.additionalParameters.containsKey("limit")) {
+                    urlTemplate += "&limit=" + this.additionalParameters.get("limit");
+                }
+                yield urlTemplate;
+            }
             case PAIKKA -> {
                 String urlTemplate = this.url + "/api/v1/reverse?lat={lat}&lon={lng}";
                 if (this.additionalParameters.containsKey("language")) {

--- a/src/main/resources/db/migration/V90__add_additional_parameters_to_photon.sql
+++ b/src/main/resources/db/migration/V90__add_additional_parameters_to_photon.sql
@@ -1,0 +1,1 @@
+UPDATE geocode_services SET additional_params = '{"limit": "10", "radius": "0.03"}' WHERE type = 'PHOTON';

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -911,7 +911,7 @@ geocoding.service.url=URL Template
 geocoding.service.api_key=API Key
 geocoding.service.language=Language (Optional)
 geocoding.service.limit=Limit (Optional)
-
+geocoding.service.additional_parameters.search_distance=Search Distance (Optional)
 geocoding.test.button=Test Connection
 geocoding.test.success=Connection successful!
 geocoding.test.error=Connection failed: {0}

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -412,6 +412,11 @@ details > div {
     padding: 16px;
 }
 
+.form-group details summary {
+    font-weight: normal;
+    font-size: 1em;
+}
+
 input:focus {
     outline: 0;
     /* some people use shadows too */

--- a/src/main/resources/templates/settings/fragments/geocoding.html
+++ b/src/main/resources/templates/settings/fragments/geocoding.html
@@ -45,7 +45,7 @@
                placeholder="e.g. en, de, fi">
     </div>
 
-    <div class="form-group" th:if="${type.name() == 'PAIKKA'}">
+    <div class="form-group" th:if="${type.name() == 'PAIKKA'  || type.name() == 'PHOTON'}">
         <label for="limit" th:text="#{geocoding.service.limit}">Limit (Optional)</label>
         <input type="number" id="limit" name="limit"
                th:value="${service != null ? service.additionalParameters['limit'] : ''}"
@@ -61,6 +61,19 @@
                     th:selected="${service != null && service.priority == p}">
             </option>
         </select>
+    </div>
+
+
+    <div class="form-group">
+        <details th:if="${type.name() == 'PHOTON'}">
+            <summary>Additional Parameters</summary>
+            <div class="form-group" th:if="${type.name() == 'PHOTON'}">
+                <label for="additionalParameters" th:text="#{geocoding.service.additional_parameters.search_distance}">Search Distance</label>
+                <input type="text" id="additionalParameters" name="radius"
+                          th:value="${service != null ? service.additionalParameters['radius'] : ''}"
+                          placeholder="0.03">
+            </div>
+        </details>
     </div>
 </div>
 

--- a/src/test/java/com/dedicatedcode/reitti/service/geocoding/GeocodeServiceTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/geocoding/GeocodeServiceTest.java
@@ -11,9 +11,11 @@ class GeocodeServiceTest {
 
     @Test
     void testGetUrlTemplatePhoton() {
-        GeocodeService service = new GeocodeService("Photon", "https://photon.example.com", true, 0, null, null, GeocoderType.PHOTON, 1, Map.of());
+
+        Map<String, String> additionalParameters = Map.of("radius", "0.03", "limit", "10");
+        GeocodeService service = new GeocodeService("Photon", "https://photon.example.com", true, 0, null, null, GeocoderType.PHOTON, 1, additionalParameters);
         String template = service.getUrlTemplate();
-        assertEquals("https://photon.example.com/reverse?lon={lng}&lat={lat}&limit=10&layer=house&layer=locality&radius=0.03", template);
+        assertEquals("https://photon.example.com/reverse?lon={lng}&lat={lat}&layer=house&layer=locality&radius=0.03&limit=10", template);
     }
 
     @Test


### PR DESCRIPTION
- Introduced support for setting `radius` and `limit` parameters in Photon reverse geocoding requests.
- Updated UI to include configurable radius input for Photon settings.
- Adjusted database migration to set default parameters for Photon.
- Modified GeocodeService logic to handle dynamic radius and limit values.