### PR TITLE
fix(926): improve geocoder test handling and error reporting

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/controller/settings/GeoCodingSettingsController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/settings/GeoCodingSettingsController.java
@@ -113,15 +113,15 @@ public class GeoCodingSettingsController {
                                     @RequestParam(required = false) Integer limit,
                                     @RequestParam(required = false) Double radius,
                                     Model model) {
+        double testLat = 48.8584;
+        double testLng = 2.2945;
         try {
-            double testLat = 48.8584;
-            double testLng = 2.2945;
             GeocodeService tmpService = verifySelection(type, url, apiKey, lang, limit, radius);
-
-            GeocodeResult result = geocodeServiceManager.test(tmpService, testLat, testLng);
+            Map<String, Object> result = geocodeServiceManager.test(tmpService, testLat, testLng);
             model.addAttribute("testResult", result);
-        } catch (Exception e) {
-            model.addAttribute("testError", e.getMessage());
+
+        }catch (Exception e) {
+            model.addAttribute("testResult", Map.of("success", false, "message", e.getMessage()));
         }
         return "settings/fragments/geocoding :: test-result-display";
     }

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/DefaultGeocodeServiceManager.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/DefaultGeocodeServiceManager.java
@@ -5,6 +5,7 @@ import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.model.geocoding.GeocodingResponse;
 import com.dedicatedcode.reitti.repository.GeocodeServiceJdbcService;
 import com.dedicatedcode.reitti.repository.GeocodingResponseJdbcService;
+import com.dedicatedcode.reitti.service.I18nService;
 import com.dedicatedcode.reitti.service.geocoding.services.ResultHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -12,10 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
@@ -34,6 +32,7 @@ public class DefaultGeocodeServiceManager implements GeocodeServiceManager {
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
     private final List<ResultHandler> resultHandlers;
+    private final I18nService i18nService;
     private final int maxErrors;
 
     public DefaultGeocodeServiceManager(GeocodeServiceJdbcService geocodeServiceJdbcService,
@@ -41,12 +40,14 @@ public class DefaultGeocodeServiceManager implements GeocodeServiceManager {
                                         RestTemplate restTemplate,
                                         ObjectMapper objectMapper,
                                         List<ResultHandler> resultHandlers,
+                                        I18nService i18nService,
                                         @Value("${reitti.geocoding.max-errors}") int maxErrors) {
         this.geocodeServiceJdbcService = geocodeServiceJdbcService;
         this.geocodingResponseJdbcService = geocodingResponseJdbcService;
         this.restTemplate = restTemplate;
         this.objectMapper = objectMapper;
         this.resultHandlers = resultHandlers;
+        this.i18nService = i18nService;
         this.maxErrors = maxErrors;
     }
 
@@ -98,9 +99,17 @@ public class DefaultGeocodeServiceManager implements GeocodeServiceManager {
     }
 
     @Override
-    public GeocodeResult test(GeocodeService service, double testLat, double testLng) {
-        List<GeocodeResult> geocodeResult = performGeocode(service, testLat, testLng, null, false);
-        return geocodeResult.stream().findFirst().orElseThrow(() -> new RuntimeException("Failed to call geocoding service: " + service.getName()));
+    public Map<String, Object> test(GeocodeService service, double testLat, double testLng) {
+        try {
+            String response = callService(service, testLat, testLng);
+            extractGeoCodeResult(service.getType(), response);
+            return Map.of("success", true, "message", i18nService.translate("geocoding.test.success"));
+
+        } catch (Exception e) {
+            logger.warn("Failed to call geocoding service [{}]: [{}]", service.getName(), e.getMessage());
+            return Map.of("success", false, "message", i18nService.translate("geocoding.test.error",e.getMessage()));
+
+        }
     }
 
     private Optional<GeocodeResult> callGeocodeService(List<? extends GeocodeService> availableServices, double latitude, double longitude, SignificantPlace significantPlace, boolean recordResponse) {
@@ -128,19 +137,8 @@ public class DefaultGeocodeServiceManager implements GeocodeServiceManager {
     }
 
     private List<GeocodeResult> performGeocode(GeocodeService service, double latitude, double longitude, SignificantPlace significantPlace, boolean recordResponse) {
-        String url = service.getUrlTemplate()
-                .replace("{lat}", String.valueOf(latitude))
-                .replace("{lng}", String.valueOf(longitude));
-
-        logger.info("Geocoding with service [{}] using URL: [{}]", service.getName(), url);
-
         try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.set(HttpHeaders.USER_AGENT, "Reitti/1.0 (+https://github.com/dedicatedcode/reitti; contact: reitti@dedicatedcode.com)");
-            HttpEntity<String> entity = new HttpEntity<>(headers);
-
-            ResponseEntity<String> responseEntity = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
-            String response = responseEntity.getBody();
+            String response = callService(service, latitude, longitude);
 
             List<GeocodeResult> geocodeResult = extractGeoCodeResult(service.getType(), response);
             if (recordResponse && !geocodeResult.isEmpty()) {
@@ -180,6 +178,25 @@ public class DefaultGeocodeServiceManager implements GeocodeServiceManager {
             recordError(service);
         }
         return Collections.emptyList();
+    }
+
+    private String callService(GeocodeService service, double latitude, double longitude) {
+        String url = service.getUrlTemplate()
+                .replace("{lat}", String.valueOf(latitude))
+                .replace("{lng}", String.valueOf(longitude));
+
+        logger.info("Geocoding with service [{}] using URL: [{}]", service.getName(), url);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.USER_AGENT, "Reitti/1.0 (+https://github.com/dedicatedcode/reitti; contact: reitti@dedicatedcode.com)");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> responseEntity = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+        if (responseEntity.getStatusCode() == HttpStatus.OK) {
+            return responseEntity.getBody();
+        } else {
+            throw new IllegalStateException("Service responded with status code [" + responseEntity.getStatusCode() + "]");
+        }
     }
 
     private List<GeocodeResult> extractGeoCodeResult(GeocoderType type, String response) throws JsonProcessingException {

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/GeocodeServiceManager.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/GeocodeServiceManager.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface GeocodeServiceManager {
     Optional<GeocodeResult> reverseGeocode(SignificantPlace significantPlace, boolean recordResponse);
 
-    GeocodeResult test(GeocodeService service, double testLat, double testLng);
+    Map<String, Object> test(GeocodeService service, double testLat, double testLng);
 
     Map<GeocoderType, List<GeocodeResult>> reverseGeocodeAll(SignificantPlace significantPlace);
 }

--- a/src/main/resources/templates/settings/fragments/geocoding.html
+++ b/src/main/resources/templates/settings/fragments/geocoding.html
@@ -118,14 +118,12 @@
 </div>
 
 <div th:fragment="test-result-display">
-    <div th:if="${testResult}" class="alert alert-success">
-        <strong>Success!</strong> Service returned a valid location:
-        <pre th:text="${testResult.toString()}"></pre>
+    <div th:if="${testResult['success']}" class="alert alert-success">
+        <span th:text="${testResult['message']}"></span>
     </div>
 
-    <div th:if="${testError}" class="alert alert-danger">
-        <strong>Test Failed:</strong>
-        <span th:text="${testError}">Error message</span>
+    <div th:unless="${testResult['success']}" class="alert alert-danger">
+        <span th:text="${testResult['message']}"></span>
     </div>
 </div>
 </body>

--- a/src/test/java/com/dedicatedcode/reitti/TestConfiguration.java
+++ b/src/test/java/com/dedicatedcode/reitti/TestConfiguration.java
@@ -27,7 +27,7 @@ public class TestConfiguration {
             }
 
             @Override
-            public GeocodeResult test(GeocodeService service, double testLat, double testLng) {
+            public Map<String, Object> test(GeocodeService service, double testLat, double testLng) {
                 return null;
             }
 

--- a/src/test/java/com/dedicatedcode/reitti/service/geocoding/DefaultGeocodeServiceManagerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/geocoding/DefaultGeocodeServiceManagerTest.java
@@ -4,6 +4,7 @@ import com.dedicatedcode.reitti.model.geo.SignificantPlace;
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.repository.GeocodeServiceJdbcService;
 import com.dedicatedcode.reitti.repository.GeocodingResponseJdbcService;
+import com.dedicatedcode.reitti.service.I18nService;
 import com.dedicatedcode.reitti.service.geocoding.services.PaikkaResultHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +41,9 @@ class DefaultGeocodeServiceManagerTest {
     @Mock
     private RestTemplate restTemplate;
 
+    @Mock
+    private I18nService i18nService;
+
     private DefaultGeocodeServiceManager geocodeServiceManager;
 
     @BeforeEach
@@ -51,6 +55,7 @@ class DefaultGeocodeServiceManagerTest {
                 restTemplate,
                 objectMapper,
                 Collections.singletonList(new PaikkaResultHandler()),
+                i18nService,
                 3
         );
     }


### PR DESCRIPTION
- Add `I18nService` to enhance localized messaging for geocoder tests.
- Refactor `test` method in `GeocodeServiceManager` to return a map with success status and localized message.
- Extract `callService` method for cleaner geocoding service calls.
- Update test configurations and templates for better error/success display in UI.