### PR TITLE
feat(944): add visibility control for satellite-layer

### DIFF
--- a/src/main/resources/static/js/map-renderer.js
+++ b/src/main/resources/static/js/map-renderer.js
@@ -828,6 +828,7 @@ class MapRenderer {
         if (!this.map || !this.map.getStyle) return;
 
         if (this.map.getLayer && this.map.getLayer('satellite-layer')) {
+            this.map.setLayoutProperty('satellite-layer', 'visibility', enable ? 'visible' : 'none');
             this.map.setPaintProperty('satellite-layer', 'raster-opacity', enable ? 1 : 0);
         }
 

--- a/src/main/resources/static/map/colored.json
+++ b/src/main/resources/static/map/colored.json
@@ -216,6 +216,7 @@
       "id": "satellite-layer",
       "type": "raster",
       "source": "satellite-source",
+      "visibility": "none",
       "paint": {
         "raster-opacity": 0,
         "raster-opacity-transition": {

--- a/src/main/resources/static/map/reitti.json
+++ b/src/main/resources/static/map/reitti.json
@@ -369,6 +369,7 @@
       "id": "satellite-layer",
       "type": "raster",
       "source": "satellite-source",
+      "visibility": "none",
       "paint": {
         "raster-opacity": 0,
         "raster-opacity-transition": {


### PR DESCRIPTION
- Add `visibility: none` to `satellite-layer` in `reitti.json` and `colored.json`
- Update `map-renderer.js` to toggle satellite-layer visibility dynamically