### PR TITLE
feat(942): add Nominatim rate limiter to geocoder services

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/DefaultGeocodeServiceManager.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/DefaultGeocodeServiceManager.java
@@ -6,6 +6,7 @@ import com.dedicatedcode.reitti.model.geocoding.GeocodingResponse;
 import com.dedicatedcode.reitti.repository.GeocodeServiceJdbcService;
 import com.dedicatedcode.reitti.repository.GeocodingResponseJdbcService;
 import com.dedicatedcode.reitti.service.I18nService;
+import com.dedicatedcode.reitti.service.geocoding.services.NominatimRateLimiter;
 import com.dedicatedcode.reitti.service.geocoding.services.ResultHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -29,6 +30,7 @@ public class DefaultGeocodeServiceManager implements GeocodeServiceManager {
 
     private final GeocodeServiceJdbcService geocodeServiceJdbcService;
     private final GeocodingResponseJdbcService geocodingResponseJdbcService;
+    private final NominatimRateLimiter nominatimRateLimiter;
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
     private final List<ResultHandler> resultHandlers;
@@ -37,6 +39,7 @@ public class DefaultGeocodeServiceManager implements GeocodeServiceManager {
 
     public DefaultGeocodeServiceManager(GeocodeServiceJdbcService geocodeServiceJdbcService,
                                         GeocodingResponseJdbcService geocodingResponseJdbcService,
+                                        NominatimRateLimiter nominatimRateLimiter,
                                         RestTemplate restTemplate,
                                         ObjectMapper objectMapper,
                                         List<ResultHandler> resultHandlers,
@@ -44,6 +47,7 @@ public class DefaultGeocodeServiceManager implements GeocodeServiceManager {
                                         @Value("${reitti.geocoding.max-errors}") int maxErrors) {
         this.geocodeServiceJdbcService = geocodeServiceJdbcService;
         this.geocodingResponseJdbcService = geocodingResponseJdbcService;
+        this.nominatimRateLimiter = nominatimRateLimiter;
         this.restTemplate = restTemplate;
         this.objectMapper = objectMapper;
         this.resultHandlers = resultHandlers;
@@ -116,7 +120,12 @@ public class DefaultGeocodeServiceManager implements GeocodeServiceManager {
         List<? extends GeocodeService> shuffledServices = new ArrayList<>(availableServices);
         Collections.shuffle(shuffledServices);
 
+        List<GeocodeService> waitingServices = new ArrayList<>();
         for (GeocodeService service : shuffledServices) {
+            if (service.getType() == GeocoderType.NOMINATIM && !nominatimRateLimiter.tryAcquire()) {
+                waitingServices.add(service);
+                continue;
+            }
             try {
                 List<GeocodeResult> result = performGeocode(service, latitude, longitude, significantPlace, recordResponse);
                 if (!result.isEmpty()) {
@@ -133,6 +142,27 @@ public class DefaultGeocodeServiceManager implements GeocodeServiceManager {
             }
         }
 
+        return handleWaitingServices(waitingServices, latitude, longitude, significantPlace, recordResponse);
+    }
+
+    private Optional<GeocodeResult> handleWaitingServices(List<GeocodeService> waitingServices, double latitude, double longitude, SignificantPlace significantPlace, boolean recordResponse) {
+        for (GeocodeService service : waitingServices) {
+            this.nominatimRateLimiter.acquireBlockingly();
+            try {
+                List<GeocodeResult> result = performGeocode(service, latitude, longitude, significantPlace, recordResponse);
+                if (!result.isEmpty()) {
+                    if (recordResponse) {
+                        recordSuccess(service);
+                    }
+                    return result.stream().findFirst();
+                }
+            } catch (Exception e) {
+                logger.warn("Calling awaited geocoding failed for service [{}]: [{}]", service.getName(), e.getMessage());
+                if (recordResponse) {
+                    recordError(service);
+                }
+            }
+        }
         return Optional.empty();
     }
 

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/NominatimRateLimiter.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/NominatimRateLimiter.java
@@ -1,0 +1,58 @@
+package com.dedicatedcode.reitti.service.geocoding.services;
+
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@Service
+public class NominatimRateLimiter {
+    private final AtomicLong lastRequestTime = new AtomicLong(0);
+    private static final long ONE_SECOND_MS = 1000;
+
+    /**
+     * Checks if Nominatim is available right now without waiting.
+     */
+    public boolean isAvailableNow() {
+        return (System.currentTimeMillis() - lastRequestTime.get()) >= ONE_SECOND_MS;
+    }
+
+    /**
+     * Attempts to acquire a slot. If a second has passed, updates the timestamp and returns true.
+     * If not, returns false (caller must wait or skip).
+     */
+    public boolean tryAcquire() {
+        long now = System.currentTimeMillis();
+        long last = lastRequestTime.get();
+        
+        if (now - last >= ONE_SECOND_MS) {
+            // Atomic Compare-And-Set to ensure thread safety without heavy synchronized blocks
+            return lastRequestTime.compareAndSet(last, now);
+        }
+        return false;
+    }
+
+    /**
+     * Forces the current thread to sleep until the 1-second window opens, then acquires it.
+     */
+    public void acquireBlockingly() {
+        while (true) {
+            long now = System.currentTimeMillis();
+            long last = lastRequestTime.get();
+            long timePassed = now - last;
+
+            if (timePassed >= ONE_SECOND_MS) {
+                if (lastRequestTime.compareAndSet(last, now)) {
+                    return; // Successfully acquired!
+                }
+            } else {
+                try {
+                    // Sleep for the remaining fraction of the second
+                    Thread.sleep(ONE_SECOND_MS - timePassed);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Thread interrupted while waiting for Nominatim rate limit", e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/NominatimResultHandler.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/NominatimResultHandler.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import java.util.*;
 
 @Service
-public class NominatimResultHandler implements ResultHandler{
+public class NominatimResultHandler implements ResultHandler {
     @Override
     public boolean canHandle(GeocoderType type) {
         return type == GeocoderType.NOMINATIM;

--- a/src/test/java/com/dedicatedcode/reitti/service/geocoding/DefaultGeocodeServiceManagerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/geocoding/DefaultGeocodeServiceManagerTest.java
@@ -5,6 +5,7 @@ import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.repository.GeocodeServiceJdbcService;
 import com.dedicatedcode.reitti.repository.GeocodingResponseJdbcService;
 import com.dedicatedcode.reitti.service.I18nService;
+import com.dedicatedcode.reitti.service.geocoding.services.NominatimRateLimiter;
 import com.dedicatedcode.reitti.service.geocoding.services.PaikkaResultHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,9 @@ class DefaultGeocodeServiceManagerTest {
     @Mock
     private I18nService i18nService;
 
+    @Mock
+    private NominatimRateLimiter nominatimRateLimiter;
+
     private DefaultGeocodeServiceManager geocodeServiceManager;
 
     @BeforeEach
@@ -52,6 +56,7 @@ class DefaultGeocodeServiceManagerTest {
         geocodeServiceManager = new DefaultGeocodeServiceManager(
                 geocodeServiceJdbcService,
                 geocodingResponseJdbcService,
+                nominatimRateLimiter,
                 restTemplate,
                 objectMapper,
                 Collections.singletonList(new PaikkaResultHandler()),


### PR DESCRIPTION
- Introduced `NominatimRateLimiter` to manage Nominatim API rate limits.
- Updated `DefaultGeocodeServiceManager` to handle rate-limited geocoding requests.
- Added rate limit checking and blocking for Nominatim geocoding in queued services.
- Implemented new tests for rate-limiting behavior.