### PR TITLE
- **fix(api): remove redundant maxPoints parameter from `findSimplifi…

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/controller/api/LocationDataApiController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/api/LocationDataApiController.java
@@ -191,7 +191,7 @@ public class LocationDataApiController {
         List<RawLocationPoint> pointsInBoxWithNeighbors;
         long start = System.nanoTime();
         if (Duration.between(startOfRange, endOfRange).toDays() > 30 && minLat == null && maxLat == null && minLng == null && maxLng == null) {
-            pointsInBoxWithNeighbors = rawLocationPointJdbcService.findSimplifiedRouteForPeriod(user, startOfRange, endOfRange, 10000);
+            pointsInBoxWithNeighbors = rawLocationPointJdbcService.findSimplifiedRouteForPeriod(user, startOfRange, endOfRange);
         } else if (minLat == null || maxLat == null || minLng == null || maxLng == null) {
             pointsInBoxWithNeighbors = this.rawLocationPointJdbcService.findByUserAndTimestampBetweenOrderByTimestampAsc(user, startOfRange, endOfRange);
             logger.trace("Loaded points in time range from database in [{}]ms", (System.nanoTime() - start) / 1_000_000);

--- a/src/main/java/com/dedicatedcode/reitti/repository/RawLocationPointJdbcService.java
+++ b/src/main/java/com/dedicatedcode/reitti/repository/RawLocationPointJdbcService.java
@@ -330,9 +330,9 @@ public class RawLocationPointJdbcService {
     public List<RawLocationPoint> findSimplifiedRouteForPeriod(
             User user,
             Instant startTime,
-            Instant endTime,
-            int maxPoints) {
+            Instant endTime) {
 
+        int maxPoints = 10000;
         // Calculate sampling interval based on time range and desired point count
         Duration period = Duration.between(startTime, endTime);
         long intervalMinutes = Math.max(1, period.toMinutes() / maxPoints);


### PR DESCRIPTION
…edRouteForPeriod`**

- Simplify logic by setting a default maxPoints value in the method implementation.

Resolves: device-ui-fixes