### PR TITLE
fix(#1057): reduce worker connections in nginx config

### DIFF
--- a/docker/tiles-cache/nginx.conf
+++ b/docker/tiles-cache/nginx.conf
@@ -1,12 +1,11 @@
 worker_processes auto;
-worker_rlimit_nofile 200000;
 
 error_log /var/log/nginx/error.log warn;
 pid /var/run/nginx.pid;
 
 events {
     use epoll;
-    worker_connections 16384;
+    worker_connections 1024;
     multi_accept on;
 }
 


### PR DESCRIPTION
- Lower `worker_connections` from `16384` to `1024` in `docker/tiles-cache/nginx.conf`.