### PR TITLE
fix(1090): update tiles cache for compatibility with Podman

### DIFF
--- a/docker/tiles-cache/Dockerfile
+++ b/docker/tiles-cache/Dockerfile
@@ -2,9 +2,14 @@ FROM nginx:1.30.1-trixie
 
 RUN mkdir -p /var/cache/nginx/custom
 
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf.template /etc/nginx/nginx.conf.template
+COPY entrypoint.sh /custom-entrypoint.sh
+RUN chmod +x /custom-entrypoint.sh
 
 EXPOSE 80
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=5 \
   CMD curl -f -s -o /dev/null -H "X-Reitti-Upstream-Url: https://tiles.dedicatedcode.com" http://localhost/custom/planet/latest/0/0/0.pbf || exit 1
+
+ENTRYPOINT ["/custom-entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/tiles-cache/entrypoint.sh
+++ b/docker/tiles-cache/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+if [ -z "$RESOLVER_IP" ]; then
+  export RESOLVER_IP=$(grep nameserver /etc/resolv.conf | awk '{print $2}' | head -n 1)
+fi
+
+echo "Using resolver IP: $RESOLVER_IP"
+
+envsubst '${RESOLVER_IP}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+exec "$@"

--- a/docker/tiles-cache/nginx.conf.template
+++ b/docker/tiles-cache/nginx.conf.template
@@ -69,7 +69,7 @@ http {
     access_log /var/log/nginx/access.log main;
 
     server_tokens off;
-    resolver 127.0.0.11 ipv6=off valid=300s;
+    resolver ${RESOLVER_IP} valid=300s;
 
     server {
         listen 80;


### PR DESCRIPTION
- Add dynamic resolver IP in `nginx.conf.template` using environment variable substitution.
- Introduce `entrypoint.sh` to handle resolver IP resolution.
- Update `Dockerfile` to include `entrypoint.sh` and update `nginx.conf.template` usage.