### PR TITLE
fix(1095): prevent duplicate entries in partition registry

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/service/processing/LocationPointStagingService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/processing/LocationPointStagingService.java
@@ -40,7 +40,7 @@ public class LocationPointStagingService {
                     tableName, partitionKey
             );
             this.jdbcTemplate.execute(sql);
-            this.jdbcTemplate.update("INSERT INTO partition_registry(partition_name) VALUES(?)", partitionKey);
+            this.jdbcTemplate.update("INSERT INTO partition_registry(partition_name) VALUES(?) ON CONFLICT DO NOTHING", partitionKey);
             log.debug("Ensured partition [{}] exists", tableName);
             initializedPartitions.add(partitionKey);
         }


### PR DESCRIPTION
- Add `ON CONFLICT DO NOTHING` to partition registry insert to avoid conflicts