### PR TITLE
Fix memory detail page map/photos never loading (#1121)

### DIFF
--- a/src/main/resources/templates/memories/view.html
+++ b/src/main/resources/templates/memories/view.html
@@ -33,6 +33,8 @@
         window.contextPath = /*[[@{/}]]*/ "/";
         window.contextPath = window.contextPath.replace(/\/$/, '');
         window.userSettings = /*[[${userSettings}]]*/ {};
+        window.reittiCustomMapStyles = /*[(${mapStylesJson})]*/ [];
+        window.reittiActiveMapStyleId = /*[[${activeMapStyleId}]]*/ null;
     </script>
 </head>
 <body class="memories-page">


### PR DESCRIPTION
> **Note:** this PR was prepared by Claude (Anthropic's AI assistant), acting on my behalf as the person who filed and diagnosed #1121. I've reviewed the change myself before opening this. — @Leppi83

Fixes #1121.

## Root cause

`memories/view.html` never sets `window.reittiCustomMapStyles` /
`window.reittiActiveMapStyleId`, unlike `workbench.html` and `index.html`
which both set them from the `mapStylesJson` / `activeMapStyleId` model
attributes. Without those globals, `MapRenderer.getMapStyleValue` throws
`Invalid map type` and the memory detail page's map + Immich photo grid get
stuck in an infinite loading spinner, while the main Timeline/Map dashboard
is unaffected.

`mapStylesJson` and `activeMapStyleId` are already supplied for **every**
request by `MapStyleControllerAdvice`, an unscoped `@ControllerAdvice` with
no `basePackages`/`assignableTypes` restriction — so `MemoryController#viewMemory`
already has these attributes available in its model, `memories/view.html`
just never reads them. No backend/controller change is needed.

## Fix

Two-line template addition, copied verbatim from the existing pattern in
`workbench.html`/`index.html`:

```diff
 window.userSettings = /*[[${userSettings}]]*/ {};
+window.reittiCustomMapStyles = /*[(${mapStylesJson})]*/ [];
+window.reittiActiveMapStyleId = /*[[${activeMapStyleId}]]*/ null;
```

I also checked every other template that includes `map-renderer.js`/
`map-controls.js` (`index.html`, `settings/map-styles.html`) — both already
set these globals correctly, so `memories/view.html` was the only page
affected.

## Testing

I don't have a local Java/Maven build environment available to run the
project's test suite for this change. Instead: this exact two-line change
has been running as a live Thymeleaf template override
(`SPRING_THYMELEAF_PREFIX` pointed at a patched copy of the templates
directory) on my own self-hosted Reitti instance for over a week, and I've
confirmed end-to-end that the memory detail page's map and Immich photos now
load correctly, matching the behavior of the main Timeline view. Happy to
add a test if you'd like one and can point me at the right pattern to follow
(e.g. asserting the model attributes / rendered script on a MockMvc request
to `MemoryControllerTest`).