### PR TITLE
**ci(1055): update GitHub Actions to latest versions**

### DIFF
--- a/.github/workflows/build-gpx-generator.yml
+++ b/.github/workflows/build-gpx-generator.yml
@@ -18,20 +18,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: dedicatedcode/reitti-gpx-generator
           tags: |
@@ -41,7 +41,7 @@ jobs:
             type=ref,event=pr
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: docs/tools/gpx-generator
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,17 +49,17 @@ jobs:
     needs: build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
           cache: maven
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Run unit tests
         run: mvn test
@@ -68,7 +68,7 @@ jobs:
           SPRING_PROFILES_ACTIVE: test,ci
 
       - name: Upload coverage reports as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-reports
           path: |

--- a/.github/workflows/controlled-release.yml
+++ b/.github/workflows/controlled-release.yml
@@ -25,7 +25,7 @@ jobs:
       tag: ${{ steps.vars.outputs.tag }}
       is_beta: ${{ steps.vars.outputs.is_beta }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set version variables
         id: vars
@@ -65,12 +65,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: release-gate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -93,31 +93,31 @@ jobs:
         run: mkdir staging && cp target/*.jar staging
 
       - name: Upload packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Package
           path: staging
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU & Buildx
-        uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+        uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
       - name: Docker meta for reitti
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           context: 'git'
           images: |
@@ -130,7 +130,7 @@ jobs:
             type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-beta') }}
 
       - name: Build and push reitti image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           context: .
@@ -140,7 +140,7 @@ jobs:
 
       - name: Docker meta for tile-cache
         id: meta-tile-cache
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           context: 'git'
           images: |
@@ -153,7 +153,7 @@ jobs:
             type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-beta') }}
 
       - name: Build and push tile-cache image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           context: ./docker/tiles-cache
@@ -165,17 +165,17 @@ jobs:
     needs: [prepare, build-and-gate]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Package
 
       - name: Create & publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
           name: ${{ needs.prepare.outputs.tag }}
@@ -198,7 +198,7 @@ jobs:
     if: failure() || cancelled()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Delete tag if verification cancelled/failed
         run: |
           gh api -X DELETE repos/${{ github.repository }}/git/refs/tags/${{ needs.prepare.outputs.tag }} || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -32,23 +32,23 @@ jobs:
       - name: Build
         run: mvn verify -DskipTests
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Docker meta for reitti
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             dedicatedcode/reitti
@@ -57,7 +57,7 @@ jobs:
             type=raw,value=develop,enable={{is_default_branch}}
             type=raw,value=next,enable=${{ github.ref_name == 'next' }}
       - name: Build and push reitti image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -66,7 +66,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       - name: Docker meta for tile-cache
         id: meta-tile-cache
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             dedicatedcode/reitti-tile-cache
@@ -75,7 +75,7 @@ jobs:
             type=raw,value=develop,enable={{is_default_branch}}
             type=raw,value=next,enable=${{ github.ref_name == 'next' }}
       - name: Build and push tile-cache image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./docker/tiles-cache
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
- Updated dependencies for all workflows to latest stable versions:
  - `actions/checkout` to `v7`
  - `docker/setup-buildx-action` to `v4`
  - `docker/login-action` to `v4`
  - `docker/metadata-action` to `v6`
  - `docker/build-push-action` to `v7`
  - `actions/setup-java` to `v5`
  - `actions/upload-artifact` to `v7`
  - `actions/download-artifact` to `v8`
  - `docker/setup-qemu-action` to `v4`
  - `softprops/action-gh-release` to `v3`
- Addressed deprecation warnings and ensured compatibility with Node.js updates.