### PR TITLE
feature(1027): add functionality to rename API tokens

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/controller/settings/ApiTokenSettingsController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/settings/ApiTokenSettingsController.java
@@ -67,6 +67,11 @@ public class ApiTokenSettingsController {
         return "settings/api-tokens :: api-token-usages";
     }
 
+    @GetMapping("/create-form")
+    public String createForm() {
+        return "settings/fragments/api-tokens :: create-form";
+    }
+
     @PostMapping
     public String createToken(@AuthenticationPrincipal User user,
                               @RequestParam String name,
@@ -153,6 +158,39 @@ public class ApiTokenSettingsController {
             model.addAttribute("token", toDto(timezone, tokenById.get()));
             return "settings/fragments/api-tokens :: link-form";
         }
+    }
+
+    @GetMapping("/{tokenId}/edit")
+    public String editForm(@AuthenticationPrincipal User user,
+                           @PathVariable Long tokenId,
+                           @RequestParam(required = false, defaultValue = "UTC") ZoneId timezone,
+                           Model model) {
+        Optional<ApiToken> tokenById = this.apiTokenService.getTokenById(user, tokenId);
+        if (tokenById.isEmpty()) {
+            throw new IllegalArgumentException("Token not found");
+        }
+        model.addAttribute("token", toDto(timezone, tokenById.get()));
+        return "settings/fragments/api-tokens :: edit-form";
+    }
+
+    @PostMapping("/{tokenId}/rename")
+    public String renameToken(@PathVariable Long tokenId,
+                              @RequestParam String name,
+                              @RequestParam(required = false, defaultValue = "UTC") ZoneId timezone,
+                              @AuthenticationPrincipal User user,
+                              Model model) {
+        Optional<ApiToken> tokenById = this.apiTokenService.getTokenById(user, tokenId);
+        if (tokenById.isEmpty()) {
+            throw new IllegalArgumentException("Token not found");
+        }
+        try {
+            apiTokenJdbcService.save(tokenById.get().withName(name));
+            model.addAttribute("successMessage", getMessage("message.success.token.renamed"));
+        } catch (Exception e) {
+            model.addAttribute("errorMessage", getMessage("message.error.generic", e.getMessage()));
+        }
+        addCommonAttributes(timezone, user, model);
+        return "settings/api-tokens :: api-tokens-content";
     }
 
     @GetMapping("/tokens")

--- a/src/main/java/com/dedicatedcode/reitti/controller/settings/DeviceSettingsController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/settings/DeviceSettingsController.java
@@ -93,7 +93,15 @@ public class DeviceSettingsController {
         boolean hasAvatar = this.avatarService.getInfo(user.getId(), device.id()).isPresent();
         model.addAttribute("hasAvatar", hasAvatar);
 
-        return "settings/devices :: device-edit-form";
+        return "settings/fragments/devices :: device-edit-form";
+    }
+
+    @GetMapping("/create-form")
+    public String createForm(@AuthenticationPrincipal User user,
+                             Model model) {
+        model.addAttribute("defaultColors", getDefaultColors());
+        model.addAttribute("defaultAvatars", DEFAULT_AVATARS);
+        return "settings/fragments/devices :: device-edit-form";
     }
 
     @PostMapping

--- a/src/main/java/com/dedicatedcode/reitti/model/security/ApiToken.java
+++ b/src/main/java/com/dedicatedcode/reitti/model/security/ApiToken.java
@@ -75,4 +75,8 @@ public class ApiToken {
     public ApiToken withDevice(Device device) {
         return new ApiToken(this.id, this.token, this.user, device, this.name, this.createdAt, this.lastUsedAt);
     }
+
+    public ApiToken withName(String name) {
+        return new ApiToken(this.id, this.token, this.user, this.device, name, this.createdAt, this.lastUsedAt);
+    }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -579,6 +579,7 @@ message.success.token.created=Token created successfully
 message.success.token.detached=Token successfully detached from {0}
 message.success.token.attach=Token successfully attached to {0}
 message.success.token.deleted=Token deleted successfully
+message.success.token.renamed=Token renamed successfully
 message.success.user.created=User created successfully
 message.success.user.updated=User updated successfully
 message.success.user.deleted=User deleted successfully

--- a/src/main/resources/templates/settings/api-tokens.html
+++ b/src/main/resources/templates/settings/api-tokens.html
@@ -52,6 +52,13 @@
                             <td th:text="${#temporals.format(token.createdAt(), 'yyyy-MM-dd HH:mm')}"></td>
                             <td th:text="${token.lastUsedAt() != null ? #temporals.format(token.lastUsedAt(), 'yyyy-MM-dd HH:mm') : 'Never'}"></td>
                             <td>
+                                <button class="btn"
+                                        th:attr="hx-get=@{/settings/api-tokens/{id}/edit(id=${token.id()})}"
+                                        hx-target="#token-form-container"
+                                        hx-swap="innerHTML"
+                                        hx-vals='js:{"timezone": getUserTimezone()}'
+                                        th:text="#{form.edit}">Edit
+                                </button>
                                 <th:block  th:if="${token.deviceId() != null}">
                                     <span class="token-device-linked">
                                         <a th:href="@{/settings/devices}" class="btn" th:text="#{tokens.link.to.device}">View Device</a>
@@ -89,15 +96,8 @@
                     </table>
                 </div>
 
-                <div class="settings-card">
-                    <form th:hx-post="@{/settings/api-tokens}" hx-target="#api-tokens" hx-swap="innerHTML" hx-vals='js:{"timezone": getUserTimezone()}' class="token-form"
-                          style="margin-bottom: 20px;">
-                        <div class="form-group">
-                            <label for="tokenName" th:text="#{tokens.name.label}">Token Name</label>
-                            <input type="text" id="tokenName" name="name" required th:placeholder="#{tokens.name.placeholder}">
-                        </div>
-                        <button type="submit" class="btn" th:text="#{form.create}">Create New Token</button>
-                    </form>
+                <div class="settings-card" id="token-form-container">
+                    <div th:replace="~{settings/fragments/api-tokens :: token-form-container}"></div>
                 </div>
 
 

--- a/src/main/resources/templates/settings/devices.html
+++ b/src/main/resources/templates/settings/devices.html
@@ -106,151 +106,11 @@
                 </div>
 
                 <div class="settings-card" id="device-form-container">
-                    <form th:fragment="device-edit-form" 
-                          th:hx-post="@{${device != null ? '/settings/devices/' + device.id() : '/settings/devices'}}"
-                          hx-target="#devices" hx-swap="innerHTML" method="post" class="device-form" style="margin-bottom: 20px;">
-                        <h3 th:text="#{${device != null ? 'devices.edit.title' : 'devices.add.title'}}">Add New Device</h3>
-                        <div class="form-group">
-                            <label for="deviceName" th:text="#{devices.name.label}">Device Name</label>
-                            <input type="text" id="deviceName" name="name" required th:placeholder="#{devices.name.placeholder}" th:value="${device?.name()}">
-                        </div>
-                        <div class="form-group">
-                            <h3 th:text="#{devices.color.theme.label}">Color Theme</h3>
-                            <p class="form-description" th:text="#{devices.color.theme.description}">Choose your preferred accent color for the interface.</p>
-
-                            <div class="color-picker-section">
-                                <div class="color-options">
-                                    <label class="color-option" th:each="colorOption : ${defaultColors}">
-                                        <input type="radio"
-                                               name="color"
-                                               th:value="${colorOption.key}"
-                                               th:checked="${selectedColor == colorOption.key || (selectedColor == null && colorOption.key == '#f1ba63')}"
-                                               style="display: none;">
-                                        <div class="color-swatch"
-                                             th:style="'background-color: ' + ${colorOption.key}"
-                                             th:title="${colorOption.value}"></div>
-                                    </label>
-
-                                    <!-- Custom color option -->
-                                    <label class="color-option custom-color-option">
-                                        <input type="radio"
-                                               name="color"
-                                               id="customColorRadio"
-                                               value=""
-                                               style="display: none;">
-                                        <div class="color-swatch custom-color-swatch"
-                                             id="customColorSwatch"
-                                             th:title="#{devices.color.theme.custom}">
-                                            <span class="custom-color-icon">+</span>
-                                        </div>
-                                    </label>
-                                </div>
-
-                                <!-- Custom color input -->
-                                <div class="custom-color-input-section" id="customColorInputSection" style="display: none;">
-                                    <label for="customColorInput" th:text="#{devices.color.theme.custom.input}">Custom Color:</label>
-                                    <div class="custom-color-input-wrapper">
-                                        <input type="color"
-                                               id="customColorInput"
-                                               th:value="${device != null && !#maps.containsKey(defaultColors, device.color()) ? device.color() : '#f1ba63'}"
-                                               onchange="updateCustomColor(this.value)">
-                                        <input type="text"
-                                               id="customColorText"
-                                               th:value="${device != null && !#maps.containsKey(defaultColors, device.color()) ? device.color() : '#f1ba63'}"
-                                               placeholder="#f1ba63"
-                                               pattern="^#[0-9A-Fa-f]{6}$"
-                                               onchange="updateCustomColorFromText(this.value)">
-                                    </div>
-                                </div>
-
-                                <div class="color-actions">
-                                    <button type="button"
-                                            class="btn btn-secondary"
-                                            onclick="resetToDefaultColor()"
-                                            th:text="#{devices.color.theme.reset}">Reset to Default</button>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="divider left">
-                            <span th:text="#{devices.settings.title}">Device Settings</span>
-                        </div>
-                        <div class="form-group slide-reveal-container">
-                            <input type="checkbox" name="enabled" id="deviceEnabled" th:checked="${device?.enabled() != false}">
-                            <label data-testid="enabledCheckbox" for="deviceEnabled" class="slide-reveal">
-                                <span class="slide-box"></span>
-                                <span class="label-text" th:text="#{devices.enabled.label}">Enabled</span>
-                            </label>
-                            <p class="form-description" th:text="#{devices.enabled.description}">Enable or disable this device for tracking.</p>
-                        </div>
-                        <div class="form-group slide-reveal-container">
-                            <input type="checkbox" name="showOnMap" id="deviceShowOnMap" th:checked="${device?.showOnMap() != false}">
-                            <label data-testid="showOnMapCheckbox" for="deviceShowOnMap" class="slide-reveal">
-                                <span class="slide-box"></span>
-                                <span class="label-text" th:text="#{devices.showOnMap.label}">Show on Map</span>
-                            </label>
-                            <p class="form-description" th:text="#{devices.show-on-map.description}">Enable or disable this device for tracking.</p>
-                        </div>
-                        <div class="form-group slide-reveal-container">
-                            <input type="checkbox" name="showAvatarOnMap" id="deviceShowAvatar" th:checked="${device?.showAvatar() != false}">
-                            <label data-testid="showAvatarCheckbox" for="deviceShowAvatar" class="slide-reveal">
-                                <span class="slide-box"></span>
-                                <span class="label-text" th:text="#{devices.showAvatar.label}">Show on Map</span>
-                            </label>
-                            <p class="form-description" th:text="#{devices.show-avatar-on-map.description}">When enabled, the device will show up as an avatar on the map.</p>
-                        </div>
-                        <div class="divider left">
-                            <span th:text="#{devices.avatar.label}">Profile Picture</span>
-                        </div>
-                        <div class="form-group">
-                            <!-- Current avatar display -->
-                            <div th:if="${device != null && hasAvatar}" class="current-avatar">
-                                <img th:src="${device.avatarUrl()}"
-                                     alt="Current avatar"
-                                     class="avatar">
-                            </div>
-
-                            <div class="default-avatars-section">
-                                <h4 th:text="#{users.avatar.default.title}">Choose a default avatar:</h4>
-                                <div class="default-avatars-grid">
-                                    <label th:each="defaultAvatar : ${defaultAvatars}" class="default-avatar-option">
-                                        <input type="radio" name="defaultAvatar" th:value="${defaultAvatar}" style="display: none;">
-                                        <img th:src="@{/img/avatars/default/{avatar}(avatar=${defaultAvatar})}"
-                                             th:alt="${defaultAvatar}"
-                                             class="avatar">
-                                    </label>
-                                </div>
-                            </div>
-
-                            <div class="separator">
-                                <span th:text="#{users.avatar.or}">OR</span>
-                            </div>
-
-                            <!-- Custom file upload -->
-                            <div class="custom-avatar-section">
-                                <h4 th:text="#{users.avatar.custom.title}">Upload a custom image:</h4>
-                                <div class="avatar-input-row">
-                                    <input type="file" id="avatar" name="avatar" accept="image/jpeg,image/png,image/gif,image/webp">
-                                    <button type="button"
-                                            th:if="${device != null && hasAvatar}"
-                                            class="btn btn-danger avatar-remove-btn"
-                                            onclick="removeCurrentAvatar()"
-                                            th:text="#{users.avatar.delete}">Remove current avatar</button>
-                                </div>
-                                <small th:text="#{users.avatar.requirements}">Max 2MB. JPEG, PNG, GIF, or WebP format.</small>
-                            </div>
-
-                            <input type="hidden" id="removeAvatarFlag" name="removeAvatar" value="false">
-                        </div>
-
-
-                        <button th:if="${device == null}" type="submit" class="btn" th:text="#{form.create}">Create New Device</button>
-                        <button th:if="${device != null}" type="submit" class="btn" th:text="#{form.update}">Update Device</button>
-                        <button th:if="${device != null}" type="button" class="btn btn-secondary"
-                                th:hx-get="@{/settings/devices}"
-                                hx-target="body"
-                                hx-swap="outerHTML"
-                                th:text="#{form.cancel}">Cancel</button>
-                    </form>
+                    <button class="btn"
+                            th:hx-get="@{/settings/devices/create-form}"
+                            hx-target="this"
+                            hx-swap="outerHTML"
+                            th:text="#{devices.add.title}">Create New Device</button>
                 </div>
 
             </div>
@@ -258,6 +118,7 @@
 
     </div>
 </div>
+
 <script th:inline="javascript">
     window.userSettings = /*[[${userSettings}]]*/ {}
     

--- a/src/main/resources/templates/settings/fragments/api-tokens.html
+++ b/src/main/resources/templates/settings/fragments/api-tokens.html
@@ -26,5 +26,60 @@
         </div>
     </form>
 </div>
+
+<div th:fragment="edit-form">
+    <form th:hx-post="@{'/settings/api-tokens/'+${token.id()}+'/rename'}"
+          hx-target="#api-tokens"
+          hx-vals='js:{"timezone": getUserTimezone()}'
+          hx-swap="innerHTML">
+        <div class="form-group">
+            <label for="tokenEditName" th:text="#{tokens.name.label}">Token Name</label>
+            <input type="text" id="tokenEditName" name="name" required
+                   class="form-control"
+                   th:placeholder="#{tokens.name.placeholder}"
+                   th:value="${token.name()}">
+        </div>
+        <div class="form-actions">
+            <button type="submit" class="btn">
+                <span th:text="#{form.update}">update</span>
+            </button>
+            <button type="button" class="btn btn-link"
+                    th:hx-get="@{/settings/api-tokens/tokens}"
+                    hx-swap="innerHTML"
+                    hx-target="#api-tokens">
+                <span th:text="#{form.cancel}">Cancel</span>
+            </button>
+        </div>
+    </form>
+</div>
+
+<div th:fragment="create-form">
+    <form th:hx-post="@{/settings/api-tokens}"
+          hx-target="#api-tokens"
+          hx-swap="innerHTML"
+          hx-vals='js:{"timezone": getUserTimezone()}'>
+        <div class="form-group">
+            <label for="tokenName" th:text="#{tokens.name.label}">Token Name</label>
+            <input type="text" id="tokenName" name="name" required th:placeholder="#{tokens.name.placeholder}">
+        </div>
+        <div class="form-actions">
+            <button type="submit" class="btn" th:text="#{form.create}">Create New Token</button>
+            <button type="button" class="btn btn-link"
+                    th:hx-get="@{/settings/api-tokens/tokens}"
+                    hx-swap="innerHTML"
+                    hx-target="#api-tokens">
+                <span th:text="#{form.cancel}">Cancel</span>
+            </button>
+        </div>
+    </form>
+</div>
+
+<div th:fragment="token-form-container">
+    <button class="btn"
+            th:hx-get="@{/settings/api-tokens/create-form}"
+            hx-target="this"
+            hx-swap="outerHTML"
+            th:text="#{tokens.create.title}">Create New Token</button>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/settings/fragments/devices.html
+++ b/src/main/resources/templates/settings/fragments/devices.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:lang="${#locale.toLanguageTag()}">
+<body>
+<form th:fragment="device-edit-form"
+      th:hx-post="@{${device != null ? '/settings/devices/' + device.id() : '/settings/devices'}}"
+      hx-target="#devices" hx-swap="innerHTML" method="post" class="device-form" style="margin-bottom: 20px;">
+    <h3 th:text="#{${device != null ? 'devices.edit.title' : 'devices.add.title'}}">Add New Device</h3>
+    <div class="form-group">
+        <label for="deviceName" th:text="#{devices.name.label}">Device Name</label>
+        <input type="text" id="deviceName" name="name" required th:placeholder="#{devices.name.placeholder}" th:value="${device?.name()}">
+    </div>
+    <div class="form-group">
+        <h3 th:text="#{devices.color.theme.label}">Color Theme</h3>
+        <p class="form-description" th:text="#{devices.color.theme.description}">Choose your preferred accent color for the interface.</p>
+
+        <div class="color-picker-section">
+            <div class="color-options">
+                <label class="color-option" th:each="colorOption : ${defaultColors}">
+                    <input type="radio"
+                           name="color"
+                           th:value="${colorOption.key}"
+                           th:checked="${selectedColor == colorOption.key || (selectedColor == null && colorOption.key == '#f1ba63')}"
+                           style="display: none;">
+                    <div class="color-swatch"
+                         th:style="'background-color: ' + ${colorOption.key}"
+                         th:title="${colorOption.value}"></div>
+                </label>
+
+                <label class="color-option custom-color-option">
+                    <input type="radio"
+                           name="color"
+                           id="customColorRadio"
+                           value=""
+                           style="display: none;">
+                    <div class="color-swatch custom-color-swatch"
+                         id="customColorSwatch"
+                         th:title="#{devices.color.theme.custom}">
+                        <span class="custom-color-icon">+</span>
+                    </div>
+                </label>
+            </div>
+
+            <div class="custom-color-input-section" id="customColorInputSection" style="display: none;">
+                <label for="customColorInput" th:text="#{devices.color.theme.custom.input}">Custom Color:</label>
+                <div class="custom-color-input-wrapper">
+                    <input type="color"
+                           id="customColorInput"
+                           th:value="${device != null && !#maps.containsKey(defaultColors, device.color()) ? device.color() : '#f1ba63'}"
+                           onchange="updateCustomColor(this.value)">
+                    <input type="text"
+                           id="customColorText"
+                           th:value="${device != null && !#maps.containsKey(defaultColors, device.color()) ? device.color() : '#f1ba63'}"
+                           placeholder="#f1ba63"
+                           pattern="^#[0-9A-Fa-f]{6}$"
+                           onchange="updateCustomColorFromText(this.value)">
+                </div>
+            </div>
+
+            <div class="color-actions">
+                <button type="button"
+                        class="btn btn-secondary"
+                        onclick="resetToDefaultColor()"
+                        th:text="#{devices.color.theme.reset}">Reset to Default</button>
+            </div>
+        </div>
+    </div>
+    <div class="divider left">
+        <span th:text="#{devices.settings.title}">Device Settings</span>
+    </div>
+    <div class="form-group slide-reveal-container">
+        <input type="checkbox" name="enabled" id="deviceEnabled" th:checked="${device?.enabled() != false}">
+        <label data-testid="enabledCheckbox" for="deviceEnabled" class="slide-reveal">
+            <span class="slide-box"></span>
+            <span class="label-text" th:text="#{devices.enabled.label}">Enabled</span>
+        </label>
+        <p class="form-description" th:text="#{devices.enabled.description}">Enable or disable this device for tracking.</p>
+    </div>
+    <div class="form-group slide-reveal-container">
+        <input type="checkbox" name="showOnMap" id="deviceShowOnMap" th:checked="${device?.showOnMap() != false}">
+        <label data-testid="showOnMapCheckbox" for="deviceShowOnMap" class="slide-reveal">
+            <span class="slide-box"></span>
+            <span class="label-text" th:text="#{devices.showOnMap.label}">Show on Map</span>
+        </label>
+        <p class="form-description" th:text="#{devices.show-on-map.description}">Enable or disable this device for tracking.</p>
+    </div>
+    <div class="form-group slide-reveal-container">
+        <input type="checkbox" name="showAvatarOnMap" id="deviceShowAvatar" th:checked="${device?.showAvatar() != false}">
+        <label data-testid="showAvatarCheckbox" for="deviceShowAvatar" class="slide-reveal">
+            <span class="slide-box"></span>
+            <span class="label-text" th:text="#{devices.showAvatar.label}">Show on Map</span>
+        </label>
+        <p class="form-description" th:text="#{devices.show-avatar-on-map.description}">When enabled, the device will show up as an avatar on the map.</p>
+    </div>
+    <div class="divider left">
+        <span th:text="#{devices.avatar.label}">Profile Picture</span>
+    </div>
+    <div class="form-group">
+        <div th:if="${device != null && hasAvatar}" class="current-avatar">
+            <img th:src="${device.avatarUrl()}"
+                 alt="Current avatar"
+                 class="avatar">
+        </div>
+
+        <div class="default-avatars-section">
+            <h4 th:text="#{users.avatar.default.title}">Choose a default avatar:</h4>
+            <div class="default-avatars-grid">
+                <label th:each="defaultAvatar : ${defaultAvatars}" class="default-avatar-option">
+                    <input type="radio" name="defaultAvatar" th:value="${defaultAvatar}" style="display: none;">
+                    <img th:src="@{/img/avatars/default/{avatar}(avatar=${defaultAvatar})}"
+                         th:alt="${defaultAvatar}"
+                         class="avatar">
+                </label>
+            </div>
+        </div>
+
+        <div class="separator">
+            <span th:text="#{users.avatar.or}">OR</span>
+        </div>
+
+        <div class="custom-avatar-section">
+            <h4 th:text="#{users.avatar.custom.title}">Upload a custom image:</h4>
+            <div class="avatar-input-row">
+                <input type="file" id="avatar" name="avatar" accept="image/jpeg,image/png,image/gif,image/webp">
+                <button type="button"
+                        th:if="${device != null && hasAvatar}"
+                        class="btn btn-danger avatar-remove-btn"
+                        onclick="removeCurrentAvatar()"
+                        th:text="#{users.avatar.delete}">Remove current avatar</button>
+            </div>
+            <small th:text="#{users.avatar.requirements}">Max 2MB. JPEG, PNG, GIF, or WebP format.</small>
+        </div>
+
+        <input type="hidden" id="removeAvatarFlag" name="removeAvatar" value="false">
+    </div>
+
+
+    <button th:if="${device == null}" type="submit" class="btn" th:text="#{form.create}">Create New Device</button>
+    <button th:if="${device != null}" type="submit" class="btn" th:text="#{form.update}">Update Device</button>
+    <button type="button" class="btn btn-secondary"
+            th:hx-get="@{/settings/devices}"
+            hx-target="#devices"
+            hx-swap="innerHTML"
+            th:text="#{form.cancel}">Cancel</button>
+</form>
+</body>
+</html>

--- a/src/test/java/com/dedicatedcode/reitti/controller/settings/DeviceSettingsControllerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/controller/settings/DeviceSettingsControllerTest.java
@@ -206,7 +206,7 @@ class DeviceSettingsControllerTest {
         // When
         mockMvc.perform(get("/settings/devices/edit/{deviceId}", device.id()).with(user(admin)))
                 .andExpect(status().isOk())
-                .andExpect(view().name("settings/devices :: device-edit-form"))
+                .andExpect(view().name("settings/fragments/devices :: device-edit-form"))
                 .andExpect(model().attributeExists("device", "selectedColor", "defaultColors"));
     }
 


### PR DESCRIPTION
- Added `ApiToken.withName` to support token renaming.
- Introduced edit and rename token endpoints in `ApiTokenSettingsController`.
- Updated UI to include forms for renaming and editing API tokens.
- Added success message for token renaming to `messages.properties`.
- Refactored token and device forms into reusable Thymeleaf fragments.