### PR TITLE
feature(1119): improve Geoapify reverse geocoder label selection

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/GeoapifyResultHandler.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/GeoapifyResultHandler.java
@@ -30,16 +30,22 @@ public class GeoapifyResultHandler implements ResultHandler{
 
         return nodes.stream()
                 .map(best -> best.path("properties"))
-                .map(props -> createGeoCodeResult(
-                        props.path("formatted").asText(),
-                        props.path("street").asText(""),
-                        props.path("housenumber").asText(""),
-                        props.path("postcode").asText(""),
-                        props.path("city").asText(),
-                        props.path("district").asText(),
-                        props.path("country_code").asText(),
-                        props.path("category").asText(), null
-                ))
+                .map(props -> {
+                    String name = props.path("name").asText("");
+                    String addressLine1 = props.path("address_line1").asText("");
+                    String formatted = props.path("formatted").asText("");
+                    String label = !name.isEmpty() ? name : (!addressLine1.isEmpty() ? addressLine1 : formatted);
+                    return createGeoCodeResult(
+                            label,
+                            props.path("street").asText(""),
+                            props.path("housenumber").asText(""),
+                            props.path("postcode").asText(""),
+                            props.path("city").asText(),
+                            props.path("district").asText(),
+                            props.path("country_code").asText(),
+                            props.path("category").asText(), null
+                    );
+                })
                 .filter(Objects::nonNull)
                 .toList();
 

--- a/src/test/java/com/dedicatedcode/reitti/service/geocoding/services/GeoapifyResultHandlerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/geocoding/services/GeoapifyResultHandlerTest.java
@@ -20,6 +20,88 @@ class GeoapifyResultHandlerTest {
     }
 
     @Test
+    void testHandleUsesNameAsLabel() throws Exception {
+        String json = """
+                {
+                  "features": [
+                    {
+                      "properties": {
+                        "name": "Big Ben",
+                        "address_line1": "Big Ben",
+                        "formatted": "Big Ben, Bridge Street, London, UK",
+                        "street": "Bridge Street",
+                        "housenumber": "SW1A",
+                        "city": "London",
+                        "country_code": "gb",
+                        "category": "tourism",
+                        "rank": { "confidence": 1.0 }
+                      }
+                    }
+                  ]
+                }
+                """;
+
+        List<GeocodeResult> result = handler.handle(mapper.readTree(json));
+
+        assertFalse(result.isEmpty());
+        assertEquals("Big Ben", result.getFirst().label());
+    }
+
+    @Test
+    void testHandleUsesAddressLine1WhenNameMissing() throws Exception {
+        String json = """
+                {
+                  "features": [
+                    {
+                      "properties": {
+                        "address_line1": "Bridge Street 1",
+                        "formatted": "Bridge Street 1, London, UK",
+                        "street": "Bridge Street",
+                        "housenumber": "1",
+                        "postcode": "SW1A",
+                        "city": "London",
+                        "country_code": "gb",
+                        "category": "building",
+                        "rank": { "confidence": 1.0 }
+                      }
+                    }
+                  ]
+                }
+                """;
+
+        List<GeocodeResult> result = handler.handle(mapper.readTree(json));
+
+        assertFalse(result.isEmpty());
+        assertEquals("Bridge Street 1", result.getFirst().label());
+    }
+
+    @Test
+    void testHandleFallsBackToFormatted() throws Exception {
+        String json = """
+                {
+                  "features": [
+                    {
+                      "properties": {
+                        "formatted": "London, UK",
+                        "street": "",
+                        "postcode": "",
+                        "city": "London",
+                        "country_code": "gb",
+                        "category": "administrative",
+                        "rank": { "confidence": 1.0 }
+                      }
+                    }
+                  ]
+                }
+                """;
+
+        List<GeocodeResult> result = handler.handle(mapper.readTree(json));
+
+        assertFalse(result.isEmpty());
+        assertEquals("London, UK", result.getFirst().label());
+    }
+
+    @Test
     void testHandleSuccess() throws Exception {
         String json = """
                 {


### PR DESCRIPTION
- Use "name" as primary label, fallback to "address_line1", then "formatted"
- Add tests for label selection logic