### PR TITLE
feature(#1179) Add minimum-idle configuration to PostgreSQL datasource

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,8 @@ spring.messages.fallback-to-system-locale=false
 spring.datasource.url=jdbc:postgresql://localhost:5432/reittidb
 spring.datasource.username=reitti
 spring.datasource.password=reitti
-spring.datasource.hikari.maximum-pool-size=30
+spring.datasource.hikari.maximum-pool-size=20
+spring.datasource.hikari.minimum-idle=5
 
 #Redis configuration
 spring.data.redis.host=localhost


### PR DESCRIPTION
- Set `spring.datasource.hikari.minimum-idle` to 5
- Adjusted `spring.datasource.hikari.maximum-pool-size` to 20