### PR TITLE
feature(#814) Migrate project to Spring Boot 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.16</version>
+        <version>4.1.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.dedicatedcode</groupId>
@@ -16,12 +16,11 @@
     <properties>
         <java.version>25</java.version>
         <argLine/>
-        <testcontainers.version>2.0.2</testcontainers.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -46,8 +45,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-flyway</artifactId>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
@@ -62,8 +66,8 @@
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -84,15 +88,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+            <artifactId>spring-boot-starter-security-oauth2-client</artifactId>
         </dependency>
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>
             <artifactId>thymeleaf-extras-springsecurity6</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
         <dependency>
             <groupId>net.iakovlev</groupId>
@@ -140,26 +140,22 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>1.21.3</version>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>1.21.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.redis</groupId>
-            <artifactId>testcontainers-redis</artifactId>
-            <version>2.2.4</version>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-rabbitmq</artifactId>
-            <version>2.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.redis</groupId>
+            <artifactId>testcontainers-redis</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -169,29 +165,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-test</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java-api</artifactId>
-            <version>3.7.0</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <finalName>reitti-app</finalName>

--- a/src/main/java/com/dedicatedcode/reitti/ReittiApplication.java
+++ b/src/main/java/com/dedicatedcode/reitti/ReittiApplication.java
@@ -3,7 +3,7 @@ package com.dedicatedcode.reitti;
 import com.dedicatedcode.reitti.config.FilePropertySourceInitializer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientAutoConfiguration;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication(exclude = { OAuth2ClientAutoConfiguration.class })

--- a/src/main/java/com/dedicatedcode/reitti/config/AppConfig.java
+++ b/src/main/java/com/dedicatedcode/reitti/config/AppConfig.java
@@ -2,7 +2,7 @@ package com.dedicatedcode.reitti.config;
 
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
-import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
+import org.springframework.boot.cache.autoconfigure.RedisCacheManagerBuilderCustomizer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,13 +27,9 @@ public class AppConfig {
 
     @Bean
     public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer(RedisConnectionFactory connectionFactory) {
-        return (builder) -> {
-            builder.cacheWriter(
-                    RedisCacheWriter.nonLockingRedisCacheWriter(
-                            connectionFactory,
-                            BatchStrategies.scan(1000)
-                    )
-            );
-        };
+        return (builder) -> builder.cacheWriter(
+                RedisCacheWriter.create(connectionFactory,
+                        config -> config.batchStrategy(BatchStrategies.scan(1000))
+                                .immediateWrites(true)));
     }
 }

--- a/src/main/java/com/dedicatedcode/reitti/config/FlywayCustomizer.java
+++ b/src/main/java/com/dedicatedcode/reitti/config/FlywayCustomizer.java
@@ -1,7 +1,7 @@
 package com.dedicatedcode.reitti.config;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+import org.springframework.boot.flyway.autoconfigure.FlywayConfigurationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/com/dedicatedcode/reitti/config/QuartzConfig.java
+++ b/src/main/java/com/dedicatedcode/reitti/config/QuartzConfig.java
@@ -1,7 +1,7 @@
 package com.dedicatedcode.reitti.config;
 
 import org.quartz.spi.TriggerFiredBundle;
-import org.springframework.boot.autoconfigure.quartz.SchedulerFactoryBeanCustomizer;
+import org.springframework.boot.quartz.autoconfigure.SchedulerFactoryBeanCustomizer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/dedicatedcode/reitti/config/security/CustomOidcUserService.java
+++ b/src/main/java/com/dedicatedcode/reitti/config/security/CustomOidcUserService.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Component;
@@ -21,9 +22,10 @@ import java.net.URI;
 import java.util.Optional;
 
 @Component
-public class CustomOidcUserService extends OidcUserService {
+public class CustomOidcUserService implements OAuth2UserService<OidcUserRequest, OidcUser> {
 
     private static final Logger log = LogManager.getLogger(CustomOidcUserService.class);
+    private final OidcUserService defaultUserService = new OidcUserService();
     private final UserJdbcService userJdbcService;
     private final UserService userService;
     private final AvatarService avatarService;
@@ -125,7 +127,7 @@ public class CustomOidcUserService extends OidcUserService {
 
     // Made this package-local to allow mocking this out in testing. Do not touch!
     OidcUser getDefaultUser(OidcUserRequest userRequest) {
-        return super.loadUser(userRequest);
+        return this.defaultUserService.loadUser(userRequest);
     }
 
     private static String getDisplayName(OidcUser oidcUser, String preferredUsername) {

--- a/src/main/java/com/dedicatedcode/reitti/config/security/OidcSecurityConfiguration.java
+++ b/src/main/java/com/dedicatedcode/reitti/config/security/OidcSecurityConfiguration.java
@@ -1,9 +1,9 @@
 package com.dedicatedcode.reitti.config.security;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesMapper;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientPropertiesMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;

--- a/src/main/java/com/dedicatedcode/reitti/controller/CustomErrorController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/CustomErrorController.java
@@ -5,7 +5,7 @@ import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.boot.webmvc.error.ErrorController;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -50,7 +50,7 @@ public class CustomErrorController implements ErrorController {
 
         // Log the error
         log.error("API Error {} occurred for request URI: {}, message: {}",
-                statusCode, requestUri, errorMessage, (Throwable) exception);
+                  statusCode, requestUri, errorMessage, exception);
 
         Map<String, Object> errorResponse = new HashMap<>();
         errorResponse.put("success", false);
@@ -94,7 +94,7 @@ public class CustomErrorController implements ErrorController {
 
             if (!SILENT_CODES.contains(statusCode)) {
                 log.error("Error {} occurred for request URI: {}, message: {}",
-                        statusCode, requestUri, errorMessage, (Throwable) exception);
+                          statusCode, requestUri, errorMessage, exception);
             }
             // Add custom messages for common error codes
             switch (statusCode) {
@@ -116,7 +116,7 @@ public class CustomErrorController implements ErrorController {
             model.addAttribute("error", "Internal Server Error");
             model.addAttribute("message", "An unexpected error occurred. Please try again later.");
 
-            log.error("Unknown error occurred for request URI: {}", requestUri, (Throwable) exception);
+            log.error("Unknown error occurred for request URI: {}", requestUri, exception);
         }
 
         // Add stack trace for development environments (only if localhost)

--- a/src/main/java/com/dedicatedcode/reitti/controller/MapStyleControllerAdvice.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/MapStyleControllerAdvice.java
@@ -3,11 +3,11 @@ package com.dedicatedcode.reitti.controller;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.repository.UserMapStyleJdbcService;
 import com.dedicatedcode.reitti.service.MapLibreMapStylesService;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 @ControllerAdvice
 public class MapStyleControllerAdvice {
@@ -25,7 +25,7 @@ public class MapStyleControllerAdvice {
     }
 
     @ModelAttribute("mapStylesJson")
-    public String getMapStylesConfiguration(@AuthenticationPrincipal User user) throws JsonProcessingException {
+    public String getMapStylesConfiguration(@AuthenticationPrincipal User user) throws JacksonException {
         if (user == null) { return null; }
         return this.objectMapper.writeValueAsString(this.mapLibreMapStylesService.getConfig(user));
     }

--- a/src/main/java/com/dedicatedcode/reitti/controller/StatisticsController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/StatisticsController.java
@@ -1,17 +1,17 @@
 package com.dedicatedcode.reitti.controller;
 
-import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.model.UserType;
+import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.service.I18nService;
 import com.dedicatedcode.reitti.service.StatisticsService;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 
@@ -52,7 +52,7 @@ public class StatisticsController {
         try {
             String transportStatsJson = objectMapper.writeValueAsString(statisticsService.getOverallTransportStatistics(user));
             model.addAttribute("transportStats", transportStatsJson);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             model.addAttribute("transportStats", "[]");
         }
         
@@ -72,7 +72,7 @@ public class StatisticsController {
             
             String breakdownTransportJson = objectMapper.writeValueAsString(statisticsService.getMonthlyTransportBreakdown(user, year));
             model.addAttribute("breakdownTransportData", breakdownTransportJson);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             model.addAttribute("transportStats", "[]");
             model.addAttribute("breakdownTransportData", "[]");
         }
@@ -100,7 +100,7 @@ public class StatisticsController {
             model.addAttribute("dataAvailable", !monthTransportStatistics.isEmpty() || dailyTransportBreakdown.stream().noneMatch(dt -> dt.getTransportStats().isEmpty()));
             model.addAttribute("transportStats", objectMapper.writeValueAsString(monthTransportStatistics));
             model.addAttribute("breakdownTransportData", objectMapper.writeValueAsString(dailyTransportBreakdown));
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             model.addAttribute("transportStats", "[]");
             model.addAttribute("breakdownTransportData", "[]");
         }

--- a/src/main/java/com/dedicatedcode/reitti/controller/api/TileProxyController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/api/TileProxyController.java
@@ -4,14 +4,9 @@ import com.dedicatedcode.reitti.model.map.MapStyleDataSource;
 import com.dedicatedcode.reitti.model.map.UserMapStyle;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.repository.UserMapStyleJdbcService;
-import com.dedicatedcode.reitti.service.ContextPathHolder;
 import com.dedicatedcode.reitti.service.MapLibreMapStylesService;
 import com.dedicatedcode.reitti.service.RequestHelper;
 import com.dedicatedcode.reitti.service.TileUrlUtils;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +21,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -56,7 +55,6 @@ public class TileProxyController {
     private final ObjectMapper objectMapper;
     private final UserMapStyleJdbcService userMapStyleJdbcService;
     private final MapLibreMapStylesService mapLibreMapStylesService;
-    private final ContextPathHolder contextPathHolder;
 
     private record TileSource(String tileJsonUrl, List<String> tileUrlTemplates, boolean proxyTiles) {}
 
@@ -66,8 +64,7 @@ public class TileProxyController {
             @Value("${reitti.ui.tiles.custom.service:}") String customTileService,
             ObjectMapper objectMapper,
             UserMapStyleJdbcService userMapStyleJdbcService,
-            MapLibreMapStylesService mapLibreMapStylesService,
-            ContextPathHolder contextPathHolder) {
+            MapLibreMapStylesService mapLibreMapStylesService) {
         this.tileCacheUrl = tileCacheUrl;
         this.tileCacheEnabled = StringUtils.hasText(tileCacheUrl);
         this.defaultTileService = defaultTileService;
@@ -75,7 +72,6 @@ public class TileProxyController {
         this.objectMapper = objectMapper;
         this.userMapStyleJdbcService = userMapStyleJdbcService;
         this.mapLibreMapStylesService = mapLibreMapStylesService;
-        this.contextPathHolder = contextPathHolder;
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .followRedirects(HttpClient.Redirect.NORMAL)
@@ -159,7 +155,7 @@ public class TileProxyController {
                 if (tileJson instanceof ObjectNode mutableTileJson && mutableTileJson.get("tiles") instanceof ArrayNode tiles && !tiles.isEmpty()) {
                     ArrayNode rewrittenTiles = objectMapper.createArrayNode();
                     for (JsonNode tileNode : tiles) {
-                        String tileUrl = tileNode.asText("");
+                        String tileUrl = tileNode.asString("");
                         if (tileUrl.startsWith("http://") || tileUrl.startsWith("https://")) {
                             rewrittenTiles.add(styleSourceTileUrl(styleId, sourceId, tileUrl, request));
                         } else if (!tileUrl.isBlank()) {
@@ -356,7 +352,7 @@ public class TileProxyController {
             return null;
         }
 
-        String tileUrl = tileArray.get(0).asText("");
+        String tileUrl = tileArray.get(0).asString("");
         if (tileUrl.startsWith("http://") || tileUrl.startsWith("https://")) {
             return normalizeTileTemplateForProxy(tileUrl);
         }

--- a/src/main/java/com/dedicatedcode/reitti/controller/settings/AboutController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/settings/AboutController.java
@@ -4,8 +4,6 @@ package com.dedicatedcode.reitti.controller.settings;
 import com.dedicatedcode.reitti.model.Role;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.service.VersionService;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,6 +11,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/main/java/com/dedicatedcode/reitti/controller/settings/MapStylesSettingsController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/settings/MapStylesSettingsController.java
@@ -8,7 +8,6 @@ import com.dedicatedcode.reitti.model.map.UserMapStyle;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.repository.UserMapStyleJdbcService;
 import com.dedicatedcode.reitti.service.I18nService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/dedicatedcode/reitti/controller/settings/PlacesSettingsController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/settings/PlacesSettingsController.java
@@ -1,11 +1,7 @@
 package com.dedicatedcode.reitti.controller.settings;
 
 import com.dedicatedcode.reitti.dto.PlaceInfo;
-import com.dedicatedcode.reitti.model.AvailableCountry;
-import com.dedicatedcode.reitti.model.Page;
-import com.dedicatedcode.reitti.model.PageRequest;
-import com.dedicatedcode.reitti.model.Role;
-import com.dedicatedcode.reitti.model.UserType;
+import com.dedicatedcode.reitti.model.*;
 import com.dedicatedcode.reitti.model.geo.GeoPoint;
 import com.dedicatedcode.reitti.model.geo.GeoUtils;
 import com.dedicatedcode.reitti.model.geo.SignificantPlace;
@@ -23,8 +19,6 @@ import com.dedicatedcode.reitti.service.geocoding.GeocodeResult;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeServiceManager;
 import com.dedicatedcode.reitti.service.jobs.JobSchedulingService;
 import com.dedicatedcode.reitti.service.jobs.JobType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
@@ -41,6 +35,8 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -145,7 +141,7 @@ public class PlacesSettingsController {
         PlaceChangeDetectionService.PlaceChangeAnalysis analysis = 
             placeChangeDetectionService.analyzeChanges(user, placeId, polygonData);
         
-        return new CheckUpdateResponse(analysis.isCanProceed(), analysis.getWarnings());
+        return new CheckUpdateResponse(analysis.canProceed(), analysis.warnings());
     }
 
     @PostMapping("/{placeId}/update")
@@ -206,7 +202,7 @@ public class PlacesSettingsController {
                     updatedPlace = updatedPlace.withPolygon(null);
                 }
 
-                if (!this.placeChangeDetectionService.analyzeChanges(user, placeId, polygonData).isCanProceed()) {
+                if (!this.placeChangeDetectionService.analyzeChanges(user, placeId, polygonData).canProceed()) {
                     placeJdbcService.update(updatedPlace);
                     log.info("Significant change detected for place [{}]. Will issue a recalculation of all affected dates", significantPlace);
                     this.jobSchedulingService.enqueueTask(locationDataCleanupTask, new DataCleanupService.TaskData(user, updatedPlace),
@@ -405,22 +401,7 @@ public class PlacesSettingsController {
         return geoPoints;
     }
 
-    public static class CheckUpdateResponse {
-        private final boolean canProceed;
-        private final List<String> warnings;
-
-        public CheckUpdateResponse(boolean canProceed, List<String> warnings) {
-            this.canProceed = canProceed;
-            this.warnings = warnings;
-        }
-
-        public boolean isCanProceed() {
-            return canProceed;
-        }
-
-        public List<String> getWarnings() {
-            return warnings;
-        }
+    public record CheckUpdateResponse(boolean canProceed, List<String> warnings) {
     }
 
 }

--- a/src/main/java/com/dedicatedcode/reitti/controller/translations/I18NController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/translations/I18NController.java
@@ -1,12 +1,12 @@
 package com.dedicatedcode.reitti.controller.translations;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.MessageSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.HashMap;
 import java.util.Locale;

--- a/src/main/java/com/dedicatedcode/reitti/dto/MapLibreStyleDefinition.java
+++ b/src/main/java/com/dedicatedcode/reitti/dto/MapLibreStyleDefinition.java
@@ -1,7 +1,5 @@
 package com.dedicatedcode.reitti.dto;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import java.io.Serializable;
 
 public record MapLibreStyleDefinition(

--- a/src/main/java/com/dedicatedcode/reitti/repository/GeocodeServiceJdbcService.java
+++ b/src/main/java/com/dedicatedcode/reitti/repository/GeocodeServiceJdbcService.java
@@ -2,11 +2,11 @@ package com.dedicatedcode.reitti.repository;
 
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeService;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Service;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,7 +35,7 @@ public class GeocodeServiceJdbcService {
                         additionalParams != null ? objectMapper.readerForMapOf(String.class).readValue(additionalParams) : null,
                         rs.getInt("priority"),
                         rs.getLong("version"));
-            } catch (JsonProcessingException e) {
+            } catch (JacksonException e) {
                 throw new RuntimeException(e);
             }
         };
@@ -95,7 +95,7 @@ public class GeocodeServiceJdbcService {
                 );
                 return geocodeService;
             }
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/dedicatedcode/reitti/repository/MemoryBlockImageGalleryJdbcService.java
+++ b/src/main/java/com/dedicatedcode/reitti/repository/MemoryBlockImageGalleryJdbcService.java
@@ -1,11 +1,11 @@
 package com.dedicatedcode.reitti.repository;
 
 import com.dedicatedcode.reitti.model.memory.MemoryBlockImageGallery;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/src/main/java/com/dedicatedcode/reitti/repository/MemoryClusterBlockRepository.java
+++ b/src/main/java/com/dedicatedcode/reitti/repository/MemoryClusterBlockRepository.java
@@ -1,14 +1,13 @@
 package com.dedicatedcode.reitti.repository;
 
 import com.dedicatedcode.reitti.model.memory.BlockType;
-import com.dedicatedcode.reitti.model.memory.MemoryBlockText;
 import com.dedicatedcode.reitti.model.memory.MemoryClusterBlock;
 import com.dedicatedcode.reitti.model.security.User;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/src/main/java/com/dedicatedcode/reitti/repository/MetadataOverrideJdbcService.java
+++ b/src/main/java/com/dedicatedcode/reitti/repository/MetadataOverrideJdbcService.java
@@ -2,12 +2,13 @@ package com.dedicatedcode.reitti.repository;
 
 import com.dedicatedcode.reitti.model.metadata.MemoryMetadata;
 import com.dedicatedcode.reitti.model.security.User;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/dedicatedcode/reitti/repository/PreviewProcessedVisitJdbcService.java
+++ b/src/main/java/com/dedicatedcode/reitti/repository/PreviewProcessedVisitJdbcService.java
@@ -3,14 +3,14 @@ package com.dedicatedcode.reitti.repository;
 import com.dedicatedcode.reitti.model.geo.ProcessedVisit;
 import com.dedicatedcode.reitti.model.geo.SignificantPlace;
 import com.dedicatedcode.reitti.model.security.User;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.jdbc.core.ArgumentPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -49,7 +49,7 @@ public class PreviewProcessedVisitJdbcService {
                         metadata,
                         rs.getLong("version")
                 );
-            } catch (JsonProcessingException e) {
+            } catch (JacksonException e) {
                 throw new RuntimeException(e);
             }
 

--- a/src/main/java/com/dedicatedcode/reitti/repository/ProcessedVisitJdbcService.java
+++ b/src/main/java/com/dedicatedcode/reitti/repository/ProcessedVisitJdbcService.java
@@ -3,15 +3,14 @@ package com.dedicatedcode.reitti.repository;
 import com.dedicatedcode.reitti.model.geo.ProcessedVisit;
 import com.dedicatedcode.reitti.model.geo.SignificantPlace;
 import com.dedicatedcode.reitti.model.security.User;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.jdbc.core.ArgumentPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -52,7 +51,7 @@ public class ProcessedVisitJdbcService {
                         metadata,
                         rs.getLong("version")
                 );
-            } catch (JsonProcessingException e) {
+            } catch (JacksonException e) {
                 throw new RuntimeException(e);
             }
 
@@ -154,7 +153,7 @@ public class ProcessedVisitJdbcService {
     private String asJson(Object value) {
         try {
             return this.objectMapper.writeValueAsString(value);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/dedicatedcode/reitti/repository/TripJdbcService.java
+++ b/src/main/java/com/dedicatedcode/reitti/repository/TripJdbcService.java
@@ -5,28 +5,18 @@ import com.dedicatedcode.reitti.model.geo.SignificantPlace;
 import com.dedicatedcode.reitti.model.geo.TransportModeSegment;
 import com.dedicatedcode.reitti.model.geo.Trip;
 import com.dedicatedcode.reitti.model.security.User;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Stream;
 
 @Service
@@ -74,7 +64,7 @@ public class TripJdbcService {
                     metadata,
                     rs.getLong("version")
             );
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new RuntimeException(e);
         }
     }
@@ -316,7 +306,7 @@ public class TripJdbcService {
     private String asJson(Object value) {
         try {
             return this.objectMapper.writeValueAsString(value);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/dedicatedcode/reitti/service/GeoJsonExportService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/GeoJsonExportService.java
@@ -8,8 +8,8 @@ import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.repository.DeviceJdbcService;
 import com.dedicatedcode.reitti.repository.RawLocationPointJdbcService;
 import com.dedicatedcode.reitti.repository.SourceLocationPointJdbcService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.io.Writer;

--- a/src/main/java/com/dedicatedcode/reitti/service/MapLibreMapStylesService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/MapLibreMapStylesService.java
@@ -5,17 +5,17 @@ import com.dedicatedcode.reitti.model.map.MapStyleDataSource;
 import com.dedicatedcode.reitti.model.map.UserMapStyle;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.repository.UserMapStyleJdbcService;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -318,8 +318,8 @@ public class MapLibreMapStylesService {
     }
 
     private void rewriteResourceUrls(ObjectNode style) {
-        if (style.get("glyphs") instanceof TextNode glyphsText && glyphsText.asText().startsWith("/")) {
-            style.set("glyphs", new TextNode(contextPathHolder.getContextPath() + glyphsText.asText()));
+        if (style.get("glyphs") instanceof StringNode glyphsText && glyphsText.asText().startsWith("/")) {
+            style.set("glyphs", new StringNode(contextPathHolder.getContextPath() + glyphsText.asText()));
         }
     }
 

--- a/src/main/java/com/dedicatedcode/reitti/service/PlaceChangeDetectionService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/PlaceChangeDetectionService.java
@@ -6,11 +6,11 @@ import com.dedicatedcode.reitti.model.geo.SignificantPlace;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.repository.ProcessedVisitJdbcService;
 import com.dedicatedcode.reitti.repository.SignificantPlaceJdbcService;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -159,21 +159,5 @@ public class PlaceChangeDetectionService {
         return placeJdbcService.findPlacesOverlappingWithPolygon(user.getId(), placeId, newPolygon);
     }
 
-    public static class PlaceChangeAnalysis {
-        private final boolean canProceed;
-        private final List<String> warnings;
-
-        public PlaceChangeAnalysis(boolean canProceed, List<String> warnings) {
-            this.canProceed = canProceed;
-            this.warnings = warnings;
-        }
-
-        public boolean isCanProceed() {
-            return canProceed;
-        }
-
-        public List<String> getWarnings() {
-            return warnings;
-        }
-    }
+    public record PlaceChangeAnalysis(boolean canProceed, List<String> warnings) {}
 }

--- a/src/main/java/com/dedicatedcode/reitti/service/TimelineService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/TimelineService.java
@@ -2,18 +2,14 @@ package com.dedicatedcode.reitti.service;
 
 import com.dedicatedcode.reitti.dto.timeline.SingleTimelineEntry;
 import com.dedicatedcode.reitti.model.UnitSystem;
-import com.dedicatedcode.reitti.model.geo.ProcessedVisit;
-import com.dedicatedcode.reitti.model.geo.SignificantPlace;
-import com.dedicatedcode.reitti.model.geo.TransportMode;
-import com.dedicatedcode.reitti.model.geo.TransportModeSegment;
-import com.dedicatedcode.reitti.model.geo.Trip;
+import com.dedicatedcode.reitti.model.geo.*;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.model.security.UserSettings;
 import com.dedicatedcode.reitti.repository.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import tools.jackson.core.JacksonException;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -55,7 +51,7 @@ public class TimelineService {
                 .orElse(UserSettings.defaultSettings(user.getId()));
         try {
             return buildTimelineEntries(processedVisits, trips, userTimeZone, selectedDate, userSettings, ownData);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             log.error("Unable to build timeline entries.", e);
             return Collections.emptyList();
         }
@@ -70,7 +66,7 @@ public class TimelineService {
                 .orElse(UserSettings.defaultSettings(user.getId()));
         try {
             return buildTimelineEntries(processedVisits, trips, userTimeZone, selectedDate, userSettings, ownData);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             log.error("Unable to build timeline entries.", e);
             return Collections.emptyList();
         }
@@ -79,7 +75,7 @@ public class TimelineService {
     /**
      * Build timeline entries from processed visits and trips
      */
-    private List<SingleTimelineEntry> buildTimelineEntries(List<ProcessedVisit> processedVisits, List<Trip> trips, ZoneId timezone, LocalDate selectedDate, UserSettings userSettings, boolean ownData) throws JsonProcessingException {
+    private List<SingleTimelineEntry> buildTimelineEntries(List<ProcessedVisit> processedVisits, List<Trip> trips, ZoneId timezone, LocalDate selectedDate, UserSettings userSettings, boolean ownData) throws JacksonException {
         List<SingleTimelineEntry> entries = new ArrayList<>();
 
         for (ProcessedVisit visit : processedVisits) {

--- a/src/main/java/com/dedicatedcode/reitti/service/TripApiQueryService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/TripApiQueryService.java
@@ -5,14 +5,14 @@ import com.dedicatedcode.reitti.dto.TripResponseV2;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.model.security.UserSettings;
 import com.dedicatedcode.reitti.repository.UserSettingsJdbcService;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -112,7 +112,7 @@ public class TripApiQueryService {
         try {
             // We tell Jackson to parse the string into a List of TripDTO
             return objectMapper.readValue(json, new TypeReference<>() {});
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             // Log the error and return empty or throw a custom exception
             logger.error("Failed to parse trips JSON from database", e);
             throw new RuntimeException("Data mapping error", e);

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/DefaultGeocodeServiceManager.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/DefaultGeocodeServiceManager.java
@@ -8,9 +8,6 @@ import com.dedicatedcode.reitti.repository.GeocodingResponseJdbcService;
 import com.dedicatedcode.reitti.service.I18nService;
 import com.dedicatedcode.reitti.service.geocoding.services.NominatimRateLimiter;
 import com.dedicatedcode.reitti.service.geocoding.services.ResultHandler;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,6 +15,9 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.time.Instant;
 import java.util.*;
@@ -231,7 +231,7 @@ public class DefaultGeocodeServiceManager implements GeocodeServiceManager {
         }
     }
 
-    private List<GeocodeResult> extractGeoCodeResult(GeocoderType type, String response) throws JsonProcessingException {
+    private List<GeocodeResult> extractGeoCodeResult(GeocoderType type, String response) throws JacksonException {
         JsonNode root = objectMapper.readTree(response);
         List<GeocodeResult> results = new ArrayList<>();
         this.resultHandlers.stream().filter(rh -> rh.canHandle(type)).forEach(rh -> results.addAll(rh.handle(root)));

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/GeoapifyResultHandler.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/GeoapifyResultHandler.java
@@ -2,8 +2,8 @@ package com.dedicatedcode.reitti.service.geocoding.services;
 
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeResult;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
 
 import java.util.*;
 

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/GeocodeJsonResultHandler.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/GeocodeJsonResultHandler.java
@@ -2,13 +2,12 @@ package com.dedicatedcode.reitti.service.geocoding.services;
 
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeResult;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class GeocodeJsonResultHandler implements ResultHandler {

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/NominatimResultHandler.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/NominatimResultHandler.java
@@ -2,8 +2,8 @@ package com.dedicatedcode.reitti.service.geocoding.services;
 
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeResult;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
 
 import java.util.*;
 

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/PaikkaResultHandler.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/PaikkaResultHandler.java
@@ -2,9 +2,9 @@ package com.dedicatedcode.reitti.service.geocoding.services;
 
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeResult;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import tools.jackson.databind.JsonNode;
 
 import java.util.*;
 

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/PhotonResultHandler.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/PhotonResultHandler.java
@@ -2,8 +2,8 @@ package com.dedicatedcode.reitti.service.geocoding.services;
 
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeResult;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/ResultHandler.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/services/ResultHandler.java
@@ -3,7 +3,7 @@ package com.dedicatedcode.reitti.service.geocoding.services;
 import com.dedicatedcode.reitti.model.geo.SignificantPlace;
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeResult;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import java.util.List;
 

--- a/src/main/java/com/dedicatedcode/reitti/service/h3/H3DatabaseLifecycleManager.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/h3/H3DatabaseLifecycleManager.java
@@ -2,7 +2,6 @@ package com.dedicatedcode.reitti.service.h3;
 
 import com.dedicatedcode.reitti.service.jobs.JobSchedulingService;
 import com.dedicatedcode.reitti.service.jobs.JobType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.postgresql.copy.CopyManager;
 import org.postgresql.core.BaseConnection;
 import org.quartz.*;
@@ -11,16 +10,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.UUID;
 
 @DisallowConcurrentExecution
 public class H3DatabaseLifecycleManager implements Job {

--- a/src/main/java/com/dedicatedcode/reitti/service/h3/H3ManifestDownloadService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/h3/H3ManifestDownloadService.java
@@ -1,9 +1,9 @@
 package com.dedicatedcode.reitti.service.h3;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.net.URI;

--- a/src/main/java/com/dedicatedcode/reitti/service/h3/RocksDBH3Service.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/h3/RocksDBH3Service.java
@@ -1,6 +1,5 @@
 package com.dedicatedcode.reitti.service.h3;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.uber.h3core.H3Core;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -12,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/src/main/java/com/dedicatedcode/reitti/service/importer/BaseGoogleTimelineImporter.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/importer/BaseGoogleTimelineImporter.java
@@ -4,9 +4,9 @@ import com.dedicatedcode.reitti.dto.LocationPoint;
 import com.dedicatedcode.reitti.model.devices.Device;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.service.processing.LocationPointStagingService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
 
 import java.time.ZonedDateTime;
 import java.util.List;

--- a/src/main/java/com/dedicatedcode/reitti/service/importer/GeoJsonImporter.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/importer/GeoJsonImporter.java
@@ -7,16 +7,16 @@ import com.dedicatedcode.reitti.service.ImportStateHolder;
 import com.dedicatedcode.reitti.service.jobs.JobSchedulingService;
 import com.dedicatedcode.reitti.service.jobs.JobType;
 import com.dedicatedcode.reitti.service.processing.LocationPointStagingService;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.quartz.JobDetail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -145,7 +145,7 @@ public class GeoJsonImporter {
                         "pointsReceived", processedCount.get()
                 );
             }
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             logger.error("Error processing GeoJSON file", e);
             if (parentJobId != null) {
                 this.jobSchedulingService.cancel(parentJobId);

--- a/src/main/java/com/dedicatedcode/reitti/service/importer/GoogleAndroidTimelineImporter.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/importer/GoogleAndroidTimelineImporter.java
@@ -11,17 +11,16 @@ import com.dedicatedcode.reitti.service.importer.dto.Visit;
 import com.dedicatedcode.reitti.service.jobs.JobSchedulingService;
 import com.dedicatedcode.reitti.service.jobs.JobType;
 import com.dedicatedcode.reitti.service.processing.LocationPointStagingService;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.quartz.JobDetail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -66,8 +65,7 @@ public class GoogleAndroidTimelineImporter extends BaseGoogleTimelineImporter {
             );
             logger.info("Importing Google Timeline Android file for user {}", user.getUsername());
             this.stateHolder.importStarted();
-            JsonFactory factory = objectMapper.getFactory();
-            JsonParser parser = factory.createParser(inputStream);
+            JsonParser parser = objectMapper.createParser(inputStream);
 
             List<LocationPoint> batch = new ArrayList<>(stagingService.getBatchSize());
 
@@ -121,7 +119,7 @@ public class GoogleAndroidTimelineImporter extends BaseGoogleTimelineImporter {
                     "pointsReceived", processedCount.get()
             );
             
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             logger.error("Error processing Google Timeline file", e);
             if (parentJobId != null) {
                 this.jobSchedulingService.cancel(parentJobId);

--- a/src/main/java/com/dedicatedcode/reitti/service/importer/GoogleIOSTimelineImporter.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/importer/GoogleIOSTimelineImporter.java
@@ -10,18 +10,17 @@ import com.dedicatedcode.reitti.service.importer.dto.ios.TimelinePathPoint;
 import com.dedicatedcode.reitti.service.jobs.JobSchedulingService;
 import com.dedicatedcode.reitti.service.jobs.JobType;
 import com.dedicatedcode.reitti.service.processing.LocationPointStagingService;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.quartz.JobDetail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -65,8 +64,7 @@ public class GoogleIOSTimelineImporter extends BaseGoogleTimelineImporter {
                     JobType.GOOGLE_TIMELINE_IMPORT,
                     "Google Timeline IOS Import - " + originalFilename
             );
-            JsonFactory factory = objectMapper.getFactory();
-            JsonParser parser = factory.createParser(inputStream);
+            JsonParser parser = objectMapper.createParser(inputStream);
 
             List<LocationPoint> batch = new ArrayList<>(stagingService.getBatchSize());
 
@@ -117,7 +115,7 @@ public class GoogleIOSTimelineImporter extends BaseGoogleTimelineImporter {
                     "pointsReceived", processedCount.get()
             );
 
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             logger.error("Error processing Google Timeline file", e);
             if (parentJobId != null) {
                 this.jobSchedulingService.cancel(parentJobId);

--- a/src/main/java/com/dedicatedcode/reitti/service/importer/GoogleRecordsImporter.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/importer/GoogleRecordsImporter.java
@@ -7,17 +7,16 @@ import com.dedicatedcode.reitti.service.ImportStateHolder;
 import com.dedicatedcode.reitti.service.jobs.JobSchedulingService;
 import com.dedicatedcode.reitti.service.jobs.JobType;
 import com.dedicatedcode.reitti.service.processing.LocationPointStagingService;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.quartz.JobDetail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -63,8 +62,7 @@ public class GoogleRecordsImporter {
             stateHolder.importStarted();
             logger.info("Importing Google Records file for user {}", user.getUsername());
 
-            JsonFactory factory = objectMapper.getFactory();
-            JsonParser parser = factory.createParser(inputStream);
+            JsonParser parser = objectMapper.createParser(inputStream);
             parentJobId = jobSchedulingService.createParentJob(
                     user,
                     JobType.GOOGLE_TIMELINE_IMPORT,
@@ -78,7 +76,7 @@ public class GoogleRecordsImporter {
             
             // Look for "locations" array (old Records.json format)
             while (parser.nextToken() != null) {
-                if (parser.getCurrentToken() == JsonToken.FIELD_NAME) {
+                if (parser.currentToken() == JsonToken.PROPERTY_NAME) {
                     String fieldName = parser.currentName();
                     
                     if ("locations".equals(fieldName)) {
@@ -137,15 +135,15 @@ public class GoogleRecordsImporter {
         // Move to the array
         parser.nextToken(); // Should be START_ARRAY
         
-        if (parser.getCurrentToken() != JsonToken.START_ARRAY) {
+        if (parser.currentToken() != JsonToken.START_ARRAY) {
             throw new IOException("Invalid format: 'locations' is not an array");
         }
         
         // Process each location in the array
         while (parser.nextToken() != JsonToken.END_ARRAY) {
-            if (parser.getCurrentToken() == JsonToken.START_OBJECT) {
+            if (parser.currentToken() == JsonToken.START_OBJECT) {
                 // Parse the location object
-                JsonNode locationNode = objectMapper.readTree(parser);
+                JsonNode locationNode = parser.readValueAsTree();
                 
                 try {
                     LocationPoint point = convertGoogleRecordsLocation(locationNode);

--- a/src/main/java/com/dedicatedcode/reitti/service/integration/mqtt/OwnTracksProcessor.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/integration/mqtt/OwnTracksProcessor.java
@@ -5,10 +5,10 @@ import com.dedicatedcode.reitti.dto.OwntracksLocationRequest;
 import com.dedicatedcode.reitti.model.devices.Device;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.service.LocationBatchingService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
 
 import java.nio.charset.StandardCharsets;
 

--- a/src/main/java/com/dedicatedcode/reitti/service/processing/TransportModeService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/processing/TransportModeService.java
@@ -13,7 +13,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -53,11 +52,11 @@ public class TransportModeService {
         // Load all overrides for the trip's time range upfront
         List<TransportModeOverride> overrides = this.transportModeOverrideJdbcService.getTransportModeOverrides(user, tripStart, tripEnd);
         if (!overrides.isEmpty()) {
-            log.debug("segmentTrip: loaded {} override(s) for trip [{}..{}]", overrides.size(), tripStart, tripEnd);
+            log.trace("segmentTrip: loaded {} override(s) for trip [{}..{}]", overrides.size(), tripStart, tripEnd);
         }
 
         List<ChunkClass> chunks = chunkAndClassify(points, configs);
-        log.debug("segmentTrip: {} points, {} chunks, trip [{}-{}]", points.size(), chunks.size(), tripStart, tripEnd);
+        log.trace("segmentTrip: {} points, {} chunks, trip [{}-{}]", points.size(), chunks.size(), tripStart, tripEnd);
 
         List<TransportModeSegment> result = new ArrayList<>();
         long chunkStartOffset = 0;
@@ -99,7 +98,7 @@ public class TransportModeService {
                         next.offsetSeconds() - cur.offsetSeconds(),
                         cur.distanceMeters()
                 ));
-                log.debug("segmentTrip: extended segment {} at +{}s to cover gap of {}s", i, cur.offsetSeconds(), next.offsetSeconds() - curEnd);
+                log.trace("segmentTrip: extended segment {} at +{}s to cover gap of {}s", i, cur.offsetSeconds(), next.offsetSeconds() - curEnd);
             }
         }
 
@@ -109,13 +108,13 @@ public class TransportModeService {
             result = result.stream()
                     .map(s -> new TransportModeSegment(s.mode(), s.offsetSeconds() + firstPointOffset, s.durationSeconds(), s.distanceMeters()))
                     .toList();
-            log.debug("segmentTrip: shifted {} segment(s) by +{}s (first point is {}s after tripStart)",
+            log.trace("segmentTrip: shifted {} segment(s) by +{}s (first point is {}s after tripStart)",
                     result.size(), firstPointOffset, firstPointOffset);
         }
 
         if (result.isEmpty()) {
             long duration = Duration.between(tripStart, tripEnd).getSeconds();
-            log.debug("segmentTrip: no segments after post-processing, returning single UNKNOWN");
+            log.trace("segmentTrip: no segments after post-processing, returning single UNKNOWN");
             result = List.of(new TransportModeSegment(TransportMode.UNKNOWN, 0L, Math.max(1, duration), totalDistanceMeters));
         }
 
@@ -138,7 +137,6 @@ public class TransportModeService {
         int chunkCount = 0;
         for (long offset = 0; offset < totalDuration; offset += CHUNK_DURATION_SECONDS) {
             long chunkEnd = Math.min(offset + CHUNK_DURATION_SECONDS, totalDuration);
-            Instant chunkStartTime = tripStart.plusSeconds(offset);
             Instant chunkEndTime = tripStart.plusSeconds(chunkEnd);
 
             List<RawLocationPoint> chunkPoints = new ArrayList<>();
@@ -161,7 +159,7 @@ public class TransportModeService {
             chunkCount++;
         }
 
-        log.debug("chunkAndClassify: {} chunks from {} points over {}s", chunks.size(), points.size(), totalDuration);
+        log.trace("chunkAndClassify: {} chunks from {} points over {}s", chunks.size(), points.size(), totalDuration);
         return chunks;
     }
 
@@ -221,7 +219,7 @@ public class TransportModeService {
         }
         result.add(current);
         if (mergeCount > 0) {
-            log.debug("mergeSameModeSegments: merged {} adjacent segment(s) down to {} segments", mergeCount, result.size());
+            log.trace("mergeSameModeSegments: merged {} adjacent segment(s) down to {} segments", mergeCount, result.size());
         }
         return result;
     }
@@ -260,7 +258,7 @@ public class TransportModeService {
         } while (changed);
 
         if (totalCollapsed > 0) {
-            log.debug("collapseShortSegments: collapsed {} short segment(s) (MIN_SEGMENT_DURATION_SECONDS={}s)", totalCollapsed, MIN_SEGMENT_DURATION_SECONDS);
+            log.trace("collapseShortSegments: collapsed {} short segment(s) (MIN_SEGMENT_DURATION_SECONDS={}s)", totalCollapsed, MIN_SEGMENT_DURATION_SECONDS);
         }
         return result;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,7 +13,6 @@ server.compression.mime-types=text/plain,application/json
 # Logging configuration
 
 logging.level.root = INFO
-logging.level.org.hibernate.engine.jdbc.spi.SqlExceptionHelper = FATAL
 logging.level.org.quartz.core.ErrorLogger = FATAL
 logging.level.com.dedicatedcode.reitti = INFO
 

--- a/src/test/java/com/dedicatedcode/reitti/IntegrationTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/IntegrationTest.java
@@ -1,7 +1,7 @@
 package com.dedicatedcode.reitti;
 
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;

--- a/src/test/java/com/dedicatedcode/reitti/TestConfiguration.java
+++ b/src/test/java/com/dedicatedcode/reitti/TestConfiguration.java
@@ -9,9 +9,9 @@ import com.dedicatedcode.reitti.service.h3.FileVerificationService;
 import com.dedicatedcode.reitti.service.h3.H3IndexDownloadService;
 import com.dedicatedcode.reitti.service.h3.H3Manifest;
 import com.dedicatedcode.reitti.service.h3.H3ManifestDownloadService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/test/java/com/dedicatedcode/reitti/controller/MetadataControllerIntegrationTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/controller/MetadataControllerIntegrationTest.java
@@ -2,7 +2,6 @@ package com.dedicatedcode.reitti.controller;
 
 import com.dedicatedcode.reitti.IntegrationTest;
 import com.dedicatedcode.reitti.TestingService;
-import com.dedicatedcode.reitti.model.geo.ProcessedVisit;
 import com.dedicatedcode.reitti.model.geo.SignificantPlace;
 import com.dedicatedcode.reitti.model.geo.TransportMode;
 import com.dedicatedcode.reitti.model.metadata.MemoryMetadata;
@@ -12,15 +11,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.PreparedStatement;
 import java.sql.Statement;
@@ -30,7 +26,8 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 

--- a/src/test/java/com/dedicatedcode/reitti/controller/api/TileProxyControllerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/controller/api/TileProxyControllerTest.java
@@ -6,15 +6,15 @@ import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.repository.UserMapStyleJdbcService;
 import com.dedicatedcode.reitti.service.ContextPathHolder;
 import com.dedicatedcode.reitti.service.MapLibreMapStylesService;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
 
 import java.util.Optional;
 
@@ -46,8 +46,7 @@ class TileProxyControllerTest {
                 null,
                 objectMapper,
                 userMapStyleJdbcService,
-                mapLibreMapStylesService,
-                contextPathHolder
+                mapLibreMapStylesService
         );
     }
 
@@ -85,7 +84,7 @@ class TileProxyControllerTest {
         ResponseEntity<JsonNode> response = controller.getStyleSourceTileJson(user, styleId, sourceId, request);
 
         // Assert
-        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(200, response.getStatusCode().value());
         JsonNode body = response.getBody();
         assertNotNull(body);
 

--- a/src/test/java/com/dedicatedcode/reitti/controller/api/ingestion/overland/OverlandIngestionApiControllerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/controller/api/ingestion/overland/OverlandIngestionApiControllerTest.java
@@ -8,7 +8,7 @@ import com.dedicatedcode.reitti.model.security.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureWebMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/src/test/java/com/dedicatedcode/reitti/controller/api/ingestion/owntracks/OwntracksIngestionApiControllerIntegrationTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/controller/api/ingestion/owntracks/OwntracksIngestionApiControllerIntegrationTest.java
@@ -16,7 +16,7 @@ import com.dedicatedcode.reitti.service.integration.ReittiIntegrationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureWebMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;

--- a/src/test/java/com/dedicatedcode/reitti/controller/api/ingestion/owntracks/OwntracksIngestionLiveModeIntegrationTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/controller/api/ingestion/owntracks/OwntracksIngestionLiveModeIntegrationTest.java
@@ -14,7 +14,7 @@ import com.dedicatedcode.reitti.repository.UserJdbcService;
 import com.dedicatedcode.reitti.service.integration.ReittiIntegrationService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureWebMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;

--- a/src/test/java/com/dedicatedcode/reitti/repository/MemoryClusterBlockRepositoryTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/repository/MemoryClusterBlockRepositoryTest.java
@@ -4,11 +4,11 @@ import com.dedicatedcode.reitti.IntegrationTest;
 import com.dedicatedcode.reitti.TestingService;
 import com.dedicatedcode.reitti.model.memory.*;
 import com.dedicatedcode.reitti.model.security.User;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
+import tools.jackson.databind.ObjectMapper;
 
 import java.time.Instant;
 import java.util.List;

--- a/src/test/java/com/dedicatedcode/reitti/service/MapLibreMapStylesServiceTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/MapLibreMapStylesServiceTest.java
@@ -6,13 +6,13 @@ import com.dedicatedcode.reitti.model.map.MapStyleDataSource;
 import com.dedicatedcode.reitti.model.map.UserMapStyle;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.repository.UserMapStyleJdbcService;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/test/java/com/dedicatedcode/reitti/service/PlaceChangeDetectionServiceTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/PlaceChangeDetectionServiceTest.java
@@ -57,9 +57,9 @@ class PlaceChangeDetectionServiceTest {
         PlaceChangeAnalysis result = placeChangeDetectionService.analyzeChanges(testUser, place.getId(), polygonData);
 
         // Then
-        assertFalse(result.isCanProceed());
-        assertFalse(result.getWarnings().isEmpty());
-        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("The polygon boundary will be added to this place, this may affect visit detection.")));
+        assertFalse(result.canProceed());
+        assertFalse(result.warnings().isEmpty());
+        assertTrue(result.warnings().stream().anyMatch(w -> w.contains("The polygon boundary will be added to this place, this may affect visit detection.")));
     }
 
     @Test
@@ -77,9 +77,9 @@ class PlaceChangeDetectionServiceTest {
         PlaceChangeAnalysis result = placeChangeDetectionService.analyzeChanges(testUser, place.getId(), null);
 
         // Then
-        assertFalse(result.isCanProceed());
-        assertFalse(result.getWarnings().isEmpty());
-        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("The polygon boundary will be removed from this place, this may affect visit detection.")));
+        assertFalse(result.canProceed());
+        assertFalse(result.warnings().isEmpty());
+        assertTrue(result.warnings().stream().anyMatch(w -> w.contains("The polygon boundary will be removed from this place, this may affect visit detection.")));
     }
 
     @Test
@@ -107,9 +107,9 @@ class PlaceChangeDetectionServiceTest {
         PlaceChangeAnalysis result = placeChangeDetectionService.analyzeChanges(testUser, place.getId(), newPolygonData);
 
         // Then
-        assertFalse(result.isCanProceed());
-        assertFalse(result.getWarnings().isEmpty());
-        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("The polygon boundary will be significantly changed, which may affect visit detection.")));
+        assertFalse(result.canProceed());
+        assertFalse(result.warnings().isEmpty());
+        assertTrue(result.warnings().stream().anyMatch(w -> w.contains("The polygon boundary will be significantly changed, which may affect visit detection.")));
     }
 
     @Test
@@ -137,8 +137,8 @@ class PlaceChangeDetectionServiceTest {
         PlaceChangeAnalysis result = placeChangeDetectionService.analyzeChanges(testUser, place.getId(), newPolygonData);
 
         // Then
-        assertTrue(result.isCanProceed());
-        assertTrue(result.getWarnings().isEmpty());
+        assertTrue(result.canProceed());
+        assertTrue(result.warnings().isEmpty());
     }
 
     @Test
@@ -167,9 +167,9 @@ class PlaceChangeDetectionServiceTest {
         PlaceChangeAnalysis result = placeChangeDetectionService.analyzeChanges(testUser, newPlace.getId(), overlappingPolygonData);
 
         // Then
-        assertFalse(result.isCanProceed());
-        assertFalse(result.getWarnings().isEmpty());
-        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("The new boundary will overlap with 1 existing place, which may cause visits to be reassigned between places and affect trip calculations")));
+        assertFalse(result.canProceed());
+        assertFalse(result.warnings().isEmpty());
+        assertTrue(result.warnings().stream().anyMatch(w -> w.contains("The new boundary will overlap with 1 existing place, which may cause visits to be reassigned between places and affect trip calculations")));
     }
 
     @Test
@@ -182,9 +182,9 @@ class PlaceChangeDetectionServiceTest {
         PlaceChangeAnalysis result = placeChangeDetectionService.analyzeChanges(testUser, place.getId(), invalidPolygonData);
 
         // Then
-        assertFalse(result.isCanProceed());
-        assertFalse(result.getWarnings().isEmpty());
-        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("An error occurred while checking the update")));
+        assertFalse(result.canProceed());
+        assertFalse(result.warnings().isEmpty());
+        assertTrue(result.warnings().stream().anyMatch(w -> w.contains("An error occurred while checking the update")));
     }
 
     @Test
@@ -202,9 +202,9 @@ class PlaceChangeDetectionServiceTest {
         PlaceChangeAnalysis result = placeChangeDetectionService.analyzeChanges(testUser, place.getId(), insufficientPolygonData);
 
         // Then
-        assertFalse(result.isCanProceed());
-        assertFalse(result.getWarnings().isEmpty());
-        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("An error occurred while checking the update")));
+        assertFalse(result.canProceed());
+        assertFalse(result.warnings().isEmpty());
+        assertTrue(result.warnings().stream().anyMatch(w -> w.contains("An error occurred while checking the update")));
     }
 
     @Test
@@ -223,9 +223,9 @@ class PlaceChangeDetectionServiceTest {
         PlaceChangeAnalysis result = placeChangeDetectionService.analyzeChanges(testUser, place.getId(), invalidPolygonData);
 
         // Then
-        assertFalse(result.isCanProceed());
-        assertFalse(result.getWarnings().isEmpty());
-        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("An error occurred while checking the update")));
+        assertFalse(result.canProceed());
+        assertFalse(result.warnings().isEmpty());
+        assertTrue(result.warnings().stream().anyMatch(w -> w.contains("An error occurred while checking the update")));
     }
 
     @Test
@@ -237,8 +237,8 @@ class PlaceChangeDetectionServiceTest {
         PlaceChangeAnalysis result = placeChangeDetectionService.analyzeChanges(testUser, place.getId(), null);
 
         // Then
-        assertTrue(result.isCanProceed());
-        assertTrue(result.getWarnings().isEmpty());
+        assertTrue(result.canProceed());
+        assertTrue(result.warnings().isEmpty());
     }
 
     private SignificantPlace createTestPlace(String name, double latitude, double longitude, List<GeoPoint> polygon) {

--- a/src/test/java/com/dedicatedcode/reitti/service/UserNotificationServiceTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/UserNotificationServiceTest.java
@@ -11,13 +11,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @IntegrationTest
@@ -25,7 +26,7 @@ class UserNotificationServiceTest {
     @Autowired
     private UserNotificationService userNotificationService;
 
-    @SpyBean
+    @MockitoSpyBean
     private UserSseEmitterService userSseEmitterService;
 
     @Autowired

--- a/src/test/java/com/dedicatedcode/reitti/service/geocoding/DefaultGeocodeServiceManagerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/geocoding/DefaultGeocodeServiceManagerTest.java
@@ -7,7 +7,6 @@ import com.dedicatedcode.reitti.repository.GeocodingResponseJdbcService;
 import com.dedicatedcode.reitti.service.I18nService;
 import com.dedicatedcode.reitti.service.geocoding.services.NominatimRateLimiter;
 import com.dedicatedcode.reitti.service.geocoding.services.PaikkaResultHandler;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +18,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/test/java/com/dedicatedcode/reitti/service/geocoding/services/GeoapifyResultHandlerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/geocoding/services/GeoapifyResultHandlerTest.java
@@ -2,8 +2,8 @@ package com.dedicatedcode.reitti.service.geocoding.services;
 
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeResult;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 

--- a/src/test/java/com/dedicatedcode/reitti/service/geocoding/services/GeocodeJsonResultHandlerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/geocoding/services/GeocodeJsonResultHandlerTest.java
@@ -2,11 +2,10 @@ package com.dedicatedcode.reitti.service.geocoding.services;
 
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeResult;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/dedicatedcode/reitti/service/geocoding/services/NominatimResultHandlerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/geocoding/services/NominatimResultHandlerTest.java
@@ -2,8 +2,8 @@ package com.dedicatedcode.reitti.service.geocoding.services;
 
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeResult;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 

--- a/src/test/java/com/dedicatedcode/reitti/service/geocoding/services/PaikkaResultHandlerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/geocoding/services/PaikkaResultHandlerTest.java
@@ -3,8 +3,8 @@ package com.dedicatedcode.reitti.service.geocoding.services;
 import com.dedicatedcode.reitti.model.geo.SignificantPlace;
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeResult;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.InputStream;
 import java.util.List;

--- a/src/test/java/com/dedicatedcode/reitti/service/geocoding/services/PhotonResultHandlerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/geocoding/services/PhotonResultHandlerTest.java
@@ -2,8 +2,8 @@ package com.dedicatedcode.reitti.service.geocoding.services;
 
 import com.dedicatedcode.reitti.model.geocoding.GeocoderType;
 import com.dedicatedcode.reitti.service.geocoding.GeocodeResult;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 

--- a/src/test/java/com/dedicatedcode/reitti/service/importer/GeoJsonImporterTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/importer/GeoJsonImporterTest.java
@@ -6,7 +6,6 @@ import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.service.ImportStateHolder;
 import com.dedicatedcode.reitti.service.jobs.JobSchedulingService;
 import com.dedicatedcode.reitti.service.processing.LocationPointStagingService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +13,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.JobDetail;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;

--- a/src/test/java/com/dedicatedcode/reitti/service/importer/GoogleAndroidTimelineImporterTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/importer/GoogleAndroidTimelineImporterTest.java
@@ -5,9 +5,9 @@ import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.service.ImportStateHolder;
 import com.dedicatedcode.reitti.service.jobs.JobSchedulingService;
 import com.dedicatedcode.reitti.service.processing.LocationPointStagingService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.quartz.JobDetail;
+import tools.jackson.databind.ObjectMapper;
 
 import java.time.Instant;
 import java.util.Map;

--- a/src/test/java/com/dedicatedcode/reitti/service/importer/GoogleIOSTimelineImporterTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/importer/GoogleIOSTimelineImporterTest.java
@@ -4,9 +4,9 @@ import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.service.ImportStateHolder;
 import com.dedicatedcode.reitti.service.jobs.JobSchedulingService;
 import com.dedicatedcode.reitti.service.processing.LocationPointStagingService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.quartz.JobDetail;
+import tools.jackson.databind.ObjectMapper;
 
 import java.time.Instant;
 import java.util.Map;

--- a/src/test/java/com/dedicatedcode/reitti/service/integration/ImmichIntegrationServiceTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/integration/ImmichIntegrationServiceTest.java
@@ -10,21 +10,18 @@ import com.dedicatedcode.reitti.model.geo.GeoPoint;
 import com.dedicatedcode.reitti.model.geo.RawLocationPoint;
 import com.dedicatedcode.reitti.model.integration.ImmichIntegration;
 import com.dedicatedcode.reitti.model.security.User;
-import com.dedicatedcode.reitti.repository.ImmichIntegrationJdbcService;
 import com.dedicatedcode.reitti.repository.RawLocationPointJdbcService;
 import com.dedicatedcode.reitti.service.StorageService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
+import tools.jackson.databind.ObjectMapper;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -33,7 +30,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withUnauthorizedRequest;
 
 @IntegrationTest
 class ImmichIntegrationServiceTest {

--- a/src/test/java/com/dedicatedcode/reitti/service/integration/mqtt/OwnTracksProcessorTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/integration/mqtt/OwnTracksProcessorTest.java
@@ -6,7 +6,6 @@ import com.dedicatedcode.reitti.model.UserType;
 import com.dedicatedcode.reitti.model.devices.Device;
 import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.service.LocationBatchingService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +14,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
 
 import java.time.Instant;
 


### PR DESCRIPTION
- Replace `com.fasterxml.jackson` with `tools.jackson` across codebase
- Refactor `PlaceChangeAnalysis` and `CheckUpdateResponse` with `record`
- Update Spring Boot test annotations to `boot.webmvc` equivalents
- Adjust Quartz and Flyway Boot configuration imports
- Fix `tileNode.asText()` to `tileNode.asString()` for Jackson compatibility