### PR TITLE
bugfix(#1187) Improve job metadata tracking and progress reporting

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/controller/settings/JobStatusController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/settings/JobStatusController.java
@@ -46,10 +46,9 @@ public class JobStatusController {
 
     @GetMapping("/queue-stats-content")
     public String getQueueStatsContent(@RequestParam(defaultValue = "UTC") ZoneId timezone, Model model) {
-        // Fetch all non-SSE jobs in active states
         List<JobMetadataRepository.JobMetadata> activeJobs =
                 jobMetadataRepository.findByStates(
-                        List.of(JobState.PREPARING, JobState.AWAITING, JobState.RUNNING)
+                        List.of(JobState.PREPARING, JobState.CREATED, JobState.AWAITING, JobState.RUNNING)
                 );
 
         List<JobMetadataRepository.JobMetadata> terminalJobs =
@@ -93,7 +92,6 @@ public class JobStatusController {
                 .map(parent -> buildPendingJobInfo(timezone, parent, childrenByParent, averageRuntimes))
                 .collect(Collectors.toList());
 
-        pendingJobs = pendingJobs.stream().filter(j -> !j.children().isEmpty() || jobMetadataRepository.verifyAgainstQuartz(j.id())).toList();
         // Build past job info (with duration)
         List<JobInfo> pastJobs = pastParents.stream()
                 .map(j -> mapToJobInfo(timezone, j))
@@ -138,45 +136,25 @@ public class JobStatusController {
         AverageRuntime avgRuntime = averageRuntimes.get(parent.getJobType());
         Long estimatedDuration = avgRuntime != null ? avgRuntime.getEstimatedSeconds() : null;
 
-        if (totalChildren == 0) {
-
-            return new JobInfo(
-                    base.id(),
-                    base.name(),
-                    base.description(),
-                    base.state(),
-                    base.enqueuedAt(),
-                    base.scheduledAt(),
-                    base.processingAt(),
-                    base.finishedAt(),
-                    base.canCancel(),
-                    children,
-                    completedChildren,
-                    totalChildren,
-                    estimatedDuration,
-                    base.progressPercent(),  // no progress for parent grouping
-                    base.progressMessage()
-            );
-
-        } else {
-            return new JobInfo(
-                    base.id(),
-                    base.name(),
-                    base.description(),
-                    base.state(),
-                    base.enqueuedAt(),
-                    base.scheduledAt(),
-                    base.processingAt(),
-                    base.finishedAt(),
-                    base.canCancel(),
-                    children,
-                    completedChildren,
-                    totalChildren,
-                    estimatedDuration,
-                    0,  // no progress for parent grouping
-                    null
-            );
-        }
+        // JobInfo derives percent/text from the children counts when present,
+        // otherwise it falls back to the parent's own progress values.
+        return new JobInfo(
+                base.id(),
+                base.name(),
+                base.description(),
+                base.state(),
+                base.enqueuedAt(),
+                base.scheduledAt(),
+                base.processingAt(),
+                base.finishedAt(),
+                base.canCancel(),
+                children,
+                completedChildren,
+                totalChildren,
+                estimatedDuration,
+                base.progressPercentValue(),
+                base.progressMessage()
+        );
     }
 
     private Map<JobType, AverageRuntime> calculateAverageRuntimes(List<JobMetadataRepository.JobMetadata> fullyCompleteParents) {

--- a/src/main/java/com/dedicatedcode/reitti/repository/JobMetadataRepository.java
+++ b/src/main/java/com/dedicatedcode/reitti/repository/JobMetadataRepository.java
@@ -107,12 +107,6 @@ public class JobMetadataRepository {
     }
 
     @Transactional(isolation = Isolation.READ_UNCOMMITTED)
-    public boolean verifyAgainstQuartz(UUID jobId) {
-        String sql = "SELECT job_name FROM qrtz_triggers WHERE job_name = ?";
-        return !jdbcTemplate.queryForList(sql, jobId.toString()).isEmpty();
-    }
-
-    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
     public List<JobMetadata> findByStates(List<JobState> states) {
         if (states.isEmpty()) {
             return List.of();

--- a/src/main/java/com/dedicatedcode/reitti/service/DataCleanupService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/DataCleanupService.java
@@ -2,6 +2,7 @@ package com.dedicatedcode.reitti.service;
 
 import com.dedicatedcode.reitti.model.geo.SignificantPlace;
 import com.dedicatedcode.reitti.model.security.User;
+import com.dedicatedcode.reitti.repository.JobMetadataRepository;
 import com.dedicatedcode.reitti.repository.ProcessedVisitJdbcService;
 import com.dedicatedcode.reitti.repository.RawLocationPointJdbcService;
 import com.dedicatedcode.reitti.repository.SignificantPlaceJdbcService;
@@ -32,6 +33,7 @@ public class DataCleanupService implements Job {
     private final JobSchedulingService jobScheduler;
     private final SignificantPlaceJdbcService placeJdbcService;
     private final JobDetail processingPipelineTask;
+    private final JobMetadataRepository jobMetadataRepository;
 
 
     public DataCleanupService(TripJdbcService tripJdbcService,
@@ -39,7 +41,8 @@ public class DataCleanupService implements Job {
                               SignificantPlaceJdbcService significantPlaceJdbcService,
                               RawLocationPointJdbcService rawLocationPointJdbcService,
                               JobSchedulingService jobScheduler, SignificantPlaceJdbcService placeJdbcService,
-                              @Qualifier("processingPipelineJob") JobDetail processingPipelineTask) {
+                              @Qualifier("processingPipelineJob") JobDetail processingPipelineTask,
+                              JobMetadataRepository jobMetadataRepository) {
         this.tripJdbcService = tripJdbcService;
         this.processedVisitJdbcService = processedVisitJdbcService;
         this.significantPlaceJdbcService = significantPlaceJdbcService;
@@ -47,6 +50,7 @@ public class DataCleanupService implements Job {
         this.jobScheduler = jobScheduler;
         this.placeJdbcService = placeJdbcService;
         this.processingPipelineTask = processingPipelineTask;
+        this.jobMetadataRepository = jobMetadataRepository;
     }
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
@@ -59,15 +63,21 @@ public class DataCleanupService implements Job {
         User user = taskData.user;
         SignificantPlace updatedPlace = taskData.place;
         Long placeId = updatedPlace.getId();
+        UUID jobId = taskData.getJobId();
 
+        this.jobMetadataRepository.updateProgress(jobId, 0, 2, "Analyzing affected places ...");
         List<SignificantPlace> placesToRemove = placeJdbcService.findPlacesOverlappingWithPolygon(user.getId(), placeId, updatedPlace.getPolygon());
         List<SignificantPlace> placesToCheck = new ArrayList<>(placesToRemove);
         placesToCheck.add(updatedPlace);
         List<LocalDate> affectedDays = this.processedVisitJdbcService.getAffectedDays(placesToCheck);
-        cleanupForGeometryChange(user, placesToRemove, affectedDays, taskData.jobId);
+
+        this.jobMetadataRepository.updateProgress(jobId, 1, 2, "Removing trips, visits, places and marking points unprocessed ...");
+        cleanupForGeometryChange(user, placesToRemove, affectedDays, taskData.getParentJobId());
+
+        this.jobMetadataRepository.updateProgress(jobId, 2, 2, "Done");
     }
 
-    void cleanupForGeometryChange(User user, List<SignificantPlace> placesToRemove, List<LocalDate> affectedDays, UUID jobId) {
+    void cleanupForGeometryChange(User user, List<SignificantPlace> placesToRemove, List<LocalDate> affectedDays, UUID parentJobId) {
         long start = System.nanoTime();
 
         log.info("Cleanup for geometry change. Removing [{}] places and starting recalculation for days [{}]", placesToRemove.size(), affectedDays);
@@ -85,7 +95,7 @@ public class DataCleanupService implements Job {
         log.info("clearing processed points for days [{}] completed in {}ms", affectedDays, (System.nanoTime() - start) / 1000000);
 
         jobScheduler.enqueueTask(processingPipelineTask,
-                                 new ProcessingPipelineTask.TaskData(user.getUsername(), null, null).withParentJobId(jobId),
+                                 new ProcessingPipelineTask.TaskData(user.getUsername(), null, null).withParentJobId(parentJobId),
                                   JobSchedulingService.Metadata.builder().jobType(VISIT_TRIP_DETECTION)
                                           .user(user)
                                           .friendlyName("Detect Visits and Trips").build()

--- a/src/main/java/com/dedicatedcode/reitti/service/geocoding/ReverseGeocodingListener.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/geocoding/ReverseGeocodingListener.java
@@ -3,6 +3,7 @@ package com.dedicatedcode.reitti.service.geocoding;
 import com.dedicatedcode.reitti.model.PlaceInformationOverride;
 import com.dedicatedcode.reitti.model.geo.SignificantPlace;
 import com.dedicatedcode.reitti.model.security.User;
+import com.dedicatedcode.reitti.repository.JobMetadataRepository;
 import com.dedicatedcode.reitti.repository.PreviewSignificantPlaceJdbcService;
 import com.dedicatedcode.reitti.repository.SignificantPlaceJdbcService;
 import com.dedicatedcode.reitti.repository.SignificantPlaceOverrideJdbcService;
@@ -32,18 +33,21 @@ public class ReverseGeocodingListener implements Job {
     private final SignificantPlaceOverrideJdbcService significantPlaceOverrideJdbcService;
     private final UserNotificationService userNotificationService;
     private final UserJdbcService userJdbcService;
+    private final JobMetadataRepository jobMetadataRepository;
 
     @Autowired
     public ReverseGeocodingListener(SignificantPlaceJdbcService significantPlaceJdbcService,
                                     PreviewSignificantPlaceJdbcService previewSignificantPlaceJdbcService,
                                     GeocodeServiceManager geocodeServiceManager, SignificantPlaceOverrideJdbcService significantPlaceOverrideJdbcService,
-                                    UserNotificationService userNotificationService, UserJdbcService userJdbcService) {
+                                    UserNotificationService userNotificationService, UserJdbcService userJdbcService,
+                                    JobMetadataRepository jobMetadataRepository) {
         this.significantPlaceJdbcService = significantPlaceJdbcService;
         this.previewSignificantPlaceJdbcService = previewSignificantPlaceJdbcService;
         this.geocodeServiceManager = geocodeServiceManager;
         this.significantPlaceOverrideJdbcService = significantPlaceOverrideJdbcService;
         this.userNotificationService = userNotificationService;
         this.userJdbcService = userJdbcService;
+        this.jobMetadataRepository = jobMetadataRepository;
     }
 
     @Override
@@ -65,6 +69,7 @@ public class ReverseGeocodingListener implements Job {
 
         SignificantPlace place = placeOptional.get();
 
+        jobMetadataRepository.updateProgress(event.getJobId(), 0, 1, "Reverse geocoding place ...");
         try {
             Optional<GeocodeResult> resultOpt = this.geocodeServiceManager.reverseGeocode(place, event.previewId() == null);
 
@@ -108,6 +113,8 @@ public class ReverseGeocodingListener implements Job {
             }
         } catch (Exception e) {
             logger.error("Error during reverse geocoding for place ID: {}", place.getId(), e);
+        } finally {
+            jobMetadataRepository.updateProgress(event.getJobId(), 1, 1, "Done");
         }
     }
 

--- a/src/main/java/com/dedicatedcode/reitti/service/h3/H3CellUpdateJob.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/h3/H3CellUpdateJob.java
@@ -1,10 +1,10 @@
 package com.dedicatedcode.reitti.service.h3;
 
 import com.dedicatedcode.reitti.model.geo.GeoPoint;
+import com.dedicatedcode.reitti.repository.JobMetadataRepository;
 import com.dedicatedcode.reitti.repository.PointReaderWriter;
 import com.dedicatedcode.reitti.service.JobContext;
 import com.dedicatedcode.reitti.service.jobs.JobSchedulingService;
-import com.dedicatedcode.reitti.service.jobs.JobType;
 import org.quartz.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,6 +12,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.io.Serializable;
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -24,12 +25,18 @@ public class H3CellUpdateJob implements Job {
     private final RocksDBH3Service rocksDbService;
     private final PointReaderWriter pointReaderWriter;
     private final JobSchedulingService jobSchedulingService;
+    private final JobMetadataRepository jobMetadataRepository;
 
-    public H3CellUpdateJob(JdbcTemplate jdbcTemplate, RocksDBH3Service rocksDbService, PointReaderWriter pointReaderWriter, JobSchedulingService jobSchedulingService) {
+    public H3CellUpdateJob(JdbcTemplate jdbcTemplate,
+                           RocksDBH3Service rocksDbService,
+                           PointReaderWriter pointReaderWriter,
+                           JobSchedulingService jobSchedulingService,
+                           JobMetadataRepository jobMetadataRepository) {
         this.jdbcTemplate = jdbcTemplate;
         this.rocksDbService = rocksDbService;
         this.pointReaderWriter = pointReaderWriter;
         this.jobSchedulingService = jobSchedulingService;
+        this.jobMetadataRepository = jobMetadataRepository;
     }
 
     @Override
@@ -37,16 +44,10 @@ public class H3CellUpdateJob implements Job {
         TaskData data = (TaskData) context.getMergedJobDataMap().get("data");
 
         if (!rocksDbService.isAvailable()) {
-            log.debug("RocksDB is not available yet. Rescheduling job.");
-            jobSchedulingService.scheduleTask(
-                    context.getJobDetail(),
-                    data,
-                    Instant.now().plusSeconds(5),
-                    JobSchedulingService.Metadata.builder()
-                            .jobType(JobType.H3_CELL_UPDATE)
-                            .friendlyName("Updating H3 Spatial Statistics (retry)")
-                            .build()
-            );
+            log.debug("RocksDB is not available yet. Deferring job.");
+            if (!jobSchedulingService.defer(context, Duration.ofSeconds(5), "Waiting for RocksDB to become available")) {
+                log.warn("Cannot defer untracked H3 cell update, dropping execution");
+            }
             return;
         }
 
@@ -71,7 +72,9 @@ public class H3CellUpdateJob implements Job {
         // Process in batches to avoid memory issues and database timeouts
         final int batchSize = 1000;
         List<Long> ids = data.pointIds;
+        jobMetadataRepository.updateProgress(data.getJobId(), 0, ids.size(), "Updating H3 cells ...");
 
+        int processed = 0;
         for (int i = 0; i < ids.size(); i += batchSize) {
             int endIndex = Math.min(i + batchSize, ids.size());
             List<Long> batch = ids.subList(i, endIndex);
@@ -84,7 +87,10 @@ public class H3CellUpdateJob implements Job {
                 case DELETION -> processBatchForDeletion(batch);
                 case PROMOTION -> processBatchForPromotion(batch);
             }
+            processed += batch.size();
+            jobMetadataRepository.updateProgress(data.getJobId(), processed, ids.size(), "Updating H3 cells ...");
         }
+        jobMetadataRepository.updateProgress(data.getJobId(), processed, ids.size(), "Done");
     }
 
     private void processMovement(List<MovedPoint> movedPoints) {

--- a/src/main/java/com/dedicatedcode/reitti/service/jobs/JobInfo.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/jobs/JobInfo.java
@@ -23,12 +23,7 @@ public record JobInfo(
         String progressMessage
 ) {
     public String progressText() {
-        if (progressMessage != null) {
-            return progressMessage;
-        } else if (totalChildren > 0) {
-            return completedChildren + " / " + totalChildren + " child jobs";
-        }
-        return null;
+        return progressMessage;
     }
 
     public int progressPercent() {

--- a/src/main/java/com/dedicatedcode/reitti/service/jobs/JobSchedulingService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/jobs/JobSchedulingService.java
@@ -4,6 +4,7 @@ import com.dedicatedcode.reitti.model.security.User;
 import com.dedicatedcode.reitti.repository.JobMetadataRepository;
 import com.dedicatedcode.reitti.service.JobContext;
 import org.quartz.*;
+import org.quartz.impl.matchers.GroupMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -12,15 +13,22 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class JobSchedulingService implements JobListener {
     private static final Logger log = LoggerFactory.getLogger(JobSchedulingService.class);
+    public static final String TASK_TRIGGER_GROUP = "reitti-tasks";
 
+    private final Set<UUID> deferredJobs = ConcurrentHashMap.newKeySet();
     private final Scheduler scheduler;
     private final JobMetadataRepository jobMetadataRepository;
 
@@ -37,7 +45,7 @@ public class JobSchedulingService implements JobListener {
 
     @Override
     public void jobToBeExecuted(JobExecutionContext context) {
-        Optional<UUID> jobId = parseJobId(context);
+        Optional<UUID> jobId = resolveJobId(context);
         jobId.ifPresent(id -> {
             this.jobMetadataRepository.updateState(id, JobState.RUNNING, Instant.now());
             log.trace("Job with ID {} is now in the state of {}", id, JobState.RUNNING);
@@ -49,7 +57,20 @@ public class JobSchedulingService implements JobListener {
         });
     }
 
-    private Optional<UUID> parseJobId(JobExecutionContext context) {
+    private Optional<UUID> resolveJobId(JobExecutionContext context) {
+        Object fromDataMap = context.getMergedJobDataMap().get("jobId");
+        if (fromDataMap instanceof String s) {
+            try {
+                return Optional.of(UUID.fromString(s));
+            } catch (IllegalArgumentException e) {
+                log.warn("Found non-UUID jobId in JobDataMap: {}", s);
+                return Optional.empty();
+            }
+        }
+        return parseJobIdFromTriggerName(context);
+    }
+
+    private Optional<UUID> parseJobIdFromTriggerName(JobExecutionContext context) {
         UUID jobId = null;
         try {
             jobId = UUID.fromString(context.getTrigger().getKey().getName());
@@ -64,8 +85,12 @@ public class JobSchedulingService implements JobListener {
 
     @Override
     public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
-        Optional<UUID> jobId = parseJobId(context);
+        Optional<UUID> jobId = resolveJobId(context);
         jobId.ifPresent(id -> {
+            if (deferredJobs.remove(id)) {
+                log.trace("Job with ID {} was deferred, skipping terminal state update", id);
+                return;
+            }
             JobState state = (jobException == null) ? JobState.COMPLETED : JobState.FAILED;
             this.jobMetadataRepository.updateState(id, state, Instant.now());
 
@@ -87,11 +112,10 @@ public class JobSchedulingService implements JobListener {
         UUID jobId = UUID.randomUUID();
         Instant now = Instant.now();
 
-        JobState state = scheduledAt.isAfter(now) ? JobState.AWAITING : JobState.CREATED;
         if (meta.user() == null) {
-            jobMetadataRepository.insert(jobId, jobDetail.getKey().getName(), meta.jobType(), meta.friendlyName(), state, now, scheduledAt, data.getParentJobId());
+            jobMetadataRepository.insert(jobId, jobDetail.getKey().getName(), meta.jobType(), meta.friendlyName(), JobState.AWAITING, now, scheduledAt, data.getParentJobId());
         } else {
-            jobMetadataRepository.insert(jobId, meta.user(), jobDetail.getKey().getName(), meta.jobType(), meta.friendlyName(), state, now, scheduledAt, data.getParentJobId());
+            jobMetadataRepository.insert(jobId, meta.user(), jobDetail.getKey().getName(), meta.jobType(), meta.friendlyName(), JobState.AWAITING, now, scheduledAt, data.getParentJobId());
         }
 
         JobDataMap jobDataMap = new JobDataMap();
@@ -101,7 +125,7 @@ public class JobSchedulingService implements JobListener {
         // Use jobId as the trigger name so we can easily retrieve it in the listener
         Trigger trigger = TriggerBuilder.newTrigger()
                 .forJob(jobDetail)
-                .withIdentity(jobId.toString())
+                .withIdentity(jobId.toString(), TASK_TRIGGER_GROUP)
                 .usingJobData(jobDataMap)
                 .startAt(Date.from(scheduledAt))
                 .build();
@@ -128,17 +152,76 @@ public class JobSchedulingService implements JobListener {
         });
     }
 
+    public boolean defer(JobExecutionContext context, Duration delay, String reason) {
+        Optional<UUID> jobIdOpt = resolveJobId(context);
+        if (jobIdOpt.isEmpty()) {
+            log.warn("Cannot defer untracked job {}", context.getJobDetail().getKey());
+            return false;
+        }
+        UUID jobId = jobIdOpt.get();
+        Instant nextRun = Instant.now().plus(delay);
+
+        JobDataMap jobDataMap = new JobDataMap();
+        context.getMergedJobDataMap().forEach((key, value) -> {
+            if (!"jobId".equals(key)) {
+                jobDataMap.put(key, value);
+            }
+        });
+        jobDataMap.put("jobId", jobId.toString());
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+                .forJob(context.getJobDetail())
+                // unique name: the trigger that is currently executing still occupies the plain
+                // jobId key and is only removed by quartz after the execution completes
+                .withIdentity(jobId + ":" + UUID.randomUUID(), TASK_TRIGGER_GROUP)
+                .usingJobData(jobDataMap)
+                .startAt(Date.from(nextRun))
+                .build();
+
+        try {
+            scheduler.scheduleJob(trigger);
+        } catch (SchedulerException e) {
+            throw new RuntimeException("Failed to reschedule deferred job " + jobId, e);
+        }
+
+        deferredJobs.add(jobId);
+        jobMetadataRepository.updateState(jobId, JobState.AWAITING, Instant.now());
+        jobMetadataRepository.updateProgress(jobId, 0, 0, reason);
+        log.info("Deferred job {} to {} ({})", jobId, nextRun, reason);
+        return true;
+    }
+
     public void cancel(UUID jobId) {
         log.info("Cancelling job {}", jobId);
-        Optional<JobMetadataRepository.JobMetadata> meta = jobMetadataRepository.findById(jobId);
-        if (meta.isPresent() && meta.get().getTaskId() != null) {
+        unscheduleTriggers(jobId);
+
+        List<UUID> childIds = jobMetadataRepository.findByParentJobId(jobId).stream()
+                .map(JobMetadataRepository.JobMetadata::getId)
+                .toList();
+        for (UUID childId : childIds) {
+            unscheduleTriggers(childId);
+        }
+        // deleting the parent cascades to child metadata rows
+        jobMetadataRepository.delete(jobId);
+    }
+
+    private void unscheduleTriggers(UUID jobId) {
+        Set<TriggerKey> keys = new HashSet<>();
+        keys.add(TriggerKey.triggerKey(jobId.toString()));
+        try {
+            scheduler.getTriggerKeys(GroupMatcher.triggerGroupEquals(TASK_TRIGGER_GROUP)).stream()
+                    .filter(key -> key.getName().equals(jobId.toString()) || key.getName().startsWith(jobId + ":"))
+                    .forEach(keys::add);
+        } catch (SchedulerException e) {
+            log.debug("Could not scan triggers for job {}", jobId, e);
+        }
+        for (TriggerKey key : keys) {
             try {
-                scheduler.unscheduleJob(TriggerKey.triggerKey(jobId.toString()));
+                scheduler.unscheduleJob(key);
             } catch (SchedulerException e) {
-                log.error("Failed to cancel job", e);
+                log.debug("No trigger to remove for job {} ({})", jobId, key);
             }
         }
-        jobMetadataRepository.delete(jobId);
     }
 
     public UUID createParentJob(User user, JobType jobType, String friendlyName) {

--- a/src/main/java/com/dedicatedcode/reitti/service/jobs/VisitSensitivityConfigurationRecalculationTask.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/jobs/VisitSensitivityConfigurationRecalculationTask.java
@@ -73,7 +73,7 @@ public class VisitSensitivityConfigurationRecalculationTask implements Job {
                 log.debug("Starting recalculation of all configurations");
                 this.jobMetadataRepository.updateProgress(taskData.getJobId(), 5, 5, "Starting recalculation ... ");
                 jobSchedulingService.enqueueTask(processingPipelineTask,
-                                                 new ProcessingPipelineTask.TaskData(user.getUsername(), null, null).withParentJobId(taskData.getJobId()),
+                                                 new ProcessingPipelineTask.TaskData(user.getUsername(), null, null).withParentJobId(taskData.getParentJobId()),
                                                  new JobSchedulingService.Metadata(user, JobType.LOCATION_PROCESSING, "Processing location data ..."));
             });
         } catch (Exception e) {

--- a/src/main/java/com/dedicatedcode/reitti/service/processing/LocationDataCleanupTask.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/processing/LocationDataCleanupTask.java
@@ -70,7 +70,7 @@ public class LocationDataCleanupTask implements Job {
         this.metadataRepository.updateProgress(jobId, 3,4, "Schedule processing events started ...");
         if (device.defaultDevice()) {
             jobScheduler.enqueueTask(updateCuratedTimelineTask,
-                                      new UpdateCuratedTimelineTask.TaskData(user, device, processedTimeRange.extend(densityTimeRange)),
+                                      new UpdateCuratedTimelineTask.TaskData(user, device, processedTimeRange.extend(densityTimeRange)).withParentJobId(data.getParentJobId()),
                                       JobSchedulingService.Metadata.builder().jobType(VISIT_TRIP_DETECTION)
                                               .user(user)
                                               .friendlyName("Detect Visits and Trips").build()

--- a/src/main/java/com/dedicatedcode/reitti/service/processing/PatchDeviceOntoTimelineTask.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/processing/PatchDeviceOntoTimelineTask.java
@@ -48,7 +48,7 @@ public class PatchDeviceOntoTimelineTask implements Job {
         log.info("Updated timeline override for user [{}], device [{}] between [{}] and [{}]", taskData.user, taskData.device, taskData.start, taskData.end);
         this.jobSchedulingService.enqueueTask(updateCuratedTimelineTask,
                                               new UpdateCuratedTimelineTask.TaskData(taskData.user, taskData.device, TimeRange.of(taskData.start, taskData.end))
-                                                      .withParentJobId(taskData.getJobId()), JobSchedulingService.Metadata.builder()
+                                                      .withParentJobId(taskData.getParentJobId()), JobSchedulingService.Metadata.builder()
                                                       .user(taskData.user)
                                                       .friendlyName(i18n.translate("jobs.recalculate_timeline.stitching.friendly_name", taskData.start, taskData.end))
                                                       .jobType(JobType.TIMELINE_STITCHING).build());

--- a/src/main/java/com/dedicatedcode/reitti/service/processing/UnifiedLocationProcessingService.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/processing/UnifiedLocationProcessingService.java
@@ -128,7 +128,8 @@ public class UnifiedLocationProcessingService {
                 event.getTraceId(),
                 detectionResult.searchStart,
                 detectionResult.searchEnd,
-                detectionResult.visits);
+                detectionResult.visits,
+                event.getParentJobId());
         logger.debug("Merging: {} visits merged into {} processed visits",
                 mergingResult.inputVisits.size(),
                 mergingResult.processedVisits.size());
@@ -285,7 +286,7 @@ public class UnifiedLocationProcessingService {
      * STEP 2: Visit Merging
      * Merges nearby visits into ProcessedVisit entities with SignificantPlaces.
      */
-    private VisitMergingResult mergeVisits(User user, String previewId, String traceId, Instant initialStart, Instant initialEnd, List<Visit> allVisits) {
+    private VisitMergingResult mergeVisits(User user, String previewId, String traceId, Instant initialStart, Instant initialEnd, List<Visit> allVisits, UUID parentJobId) {
         long start = System.currentTimeMillis();
 
         // Get merging parameters
@@ -331,7 +332,7 @@ public class UnifiedLocationProcessingService {
         }
 
         // Merge visits chronologically
-        List<ProcessedVisit> processedVisits = mergeVisitsChronologically(user, previewId, traceId, allVisits, mergeConfig);
+        List<ProcessedVisit> processedVisits = mergeVisitsChronologically(user, previewId, traceId, allVisits, mergeConfig, parentJobId);
 
         // Save processed visits
         if (previewId == null) {
@@ -492,7 +493,7 @@ public class UnifiedLocationProcessingService {
 
     private List<ProcessedVisit> mergeVisitsChronologically(
             User user, String previewId, String traceId, List<Visit> visits,
-            DetectionParameter.VisitMerging mergeConfiguration) {
+            DetectionParameter.VisitMerging mergeConfiguration, UUID parentJobId) {
         if (visits.isEmpty()) {
             return new ArrayList<>();
         }
@@ -505,7 +506,7 @@ public class UnifiedLocationProcessingService {
         Visit currentVisit = visits.getFirst();
         Instant currentStartTime = currentVisit.getStartTime();
         Instant currentEndTime = currentVisit.getEndTime();
-        SignificantPlace currentPlace = findOrCreateSignificantPlace(user, previewId, currentVisit.getLatitude(), currentVisit.getLongitude(), mergeConfiguration, traceId);
+        SignificantPlace currentPlace = findOrCreateSignificantPlace(user, previewId, currentVisit.getLatitude(), currentVisit.getLongitude(), mergeConfiguration, traceId, parentJobId);
 
         for (int i = 1; i < visits.size(); i++) {
             Visit nextVisit = visits.get(i);
@@ -518,7 +519,7 @@ public class UnifiedLocationProcessingService {
                 continue;
             }
 
-            SignificantPlace nextPlace = findOrCreateSignificantPlace(user, previewId, nextVisit.getLatitude(), nextVisit.getLongitude(), mergeConfiguration, traceId);
+            SignificantPlace nextPlace = findOrCreateSignificantPlace(user, previewId, nextVisit.getLatitude(), nextVisit.getLongitude(), mergeConfiguration, traceId, parentJobId);
 
             boolean samePlace = nextPlace.getId().equals(currentPlace.getId());
             boolean withinTimeThreshold = Duration.between(currentEndTime, nextVisit.getStartTime()).getSeconds() <= mergeConfiguration.getMaxMergeTimeBetweenSameVisits();
@@ -826,13 +827,13 @@ public class UnifiedLocationProcessingService {
     private SignificantPlace findOrCreateSignificantPlace(User user, String previewId,
                                                           double latitude, double longitude,
                                                           DetectionParameter.VisitMerging mergeConfig,
-                                                          String traceId) {
+                                                          String traceId, UUID parentJobId) {
         List<SignificantPlace> nearbyPlaces = findNearbyPlaces(user, previewId, latitude, longitude, mergeConfig);
-        return nearbyPlaces.isEmpty() ? createSignificantPlace(user, latitude, longitude, previewId, traceId) : findClosestPlace(latitude, longitude, nearbyPlaces);
+        return nearbyPlaces.isEmpty() ? createSignificantPlace(user, latitude, longitude, previewId, traceId, parentJobId) : findClosestPlace(latitude, longitude, nearbyPlaces);
     }
 
 
-    private SignificantPlace createSignificantPlace(User user, double latitude, double longitude, String previewId, String traceId) {
+    private SignificantPlace createSignificantPlace(User user, double latitude, double longitude, String previewId, String traceId, UUID parentJobId) {
         SignificantPlace significantPlace = SignificantPlace.create(latitude, longitude);
         Optional<ZoneId> timezone = this.timezoneService.getTimezone(significantPlace);
         if (timezone.isPresent()) {
@@ -850,7 +851,7 @@ public class UnifiedLocationProcessingService {
                     .withPolygon(override.get().polygon());
         }
         significantPlace = previewId == null ? this.significantPlaceJdbcService.create(user, significantPlace) : this.previewSignificantPlaceJdbcService.create(user, previewId, significantPlace);
-        publishSignificantPlaceCreatedEvent(user, significantPlace, previewId, traceId);
+        publishSignificantPlaceCreatedEvent(user, significantPlace, previewId, traceId, parentJobId);
         return significantPlace;
     }
 
@@ -871,7 +872,7 @@ public class UnifiedLocationProcessingService {
                 place2.getLatitudeCentroid(), place2.getLongitudeCentroid());
     }
 
-    private void publishSignificantPlaceCreatedEvent(User user, SignificantPlace place, String previewId, String traceId) {
+    private void publishSignificantPlaceCreatedEvent(User user, SignificantPlace place, String previewId, String traceId, UUID parentJobId) {
         ReverseGeocodingListener.TaskData event = new ReverseGeocodingListener.TaskData(
                 user.getUsername(),
                 previewId,
@@ -879,7 +880,7 @@ public class UnifiedLocationProcessingService {
                 place.getLatitudeCentroid(),
                 place.getLongitudeCentroid(),
                 traceId
-        );
+        ).withParentJobId(parentJobId);
         this.jobScheduler.enqueueTask(reverseGeocodingTask, event,
                                       JobSchedulingService.Metadata.builder()
                                           .user(user)

--- a/src/main/java/com/dedicatedcode/reitti/service/processing/UpdateCuratedTimelineTask.java
+++ b/src/main/java/com/dedicatedcode/reitti/service/processing/UpdateCuratedTimelineTask.java
@@ -2,6 +2,7 @@ package com.dedicatedcode.reitti.service.processing;
 
 import com.dedicatedcode.reitti.model.devices.Device;
 import com.dedicatedcode.reitti.model.security.User;
+import com.dedicatedcode.reitti.repository.JobMetadataRepository;
 import com.dedicatedcode.reitti.repository.RawLocationPointJdbcService;
 import com.dedicatedcode.reitti.service.JobContext;
 import com.dedicatedcode.reitti.service.jobs.JobSchedulingService;
@@ -25,17 +26,20 @@ public class UpdateCuratedTimelineTask implements Job {
     private final JobSchedulingService jobSchedulingService;
     private final JobDetail processingPipelineTask;
     private final UserProcessingLock userProcessingLock;
+    private final JobMetadataRepository jobMetadataRepository;
 
     public UpdateCuratedTimelineTask(RawLocationPointJdbcService rawLocationPointJdbcService,
                                      SyntheticPointInserter syntheticPointInserter,
                                      JobSchedulingService jobSchedulingService,
                                      @Qualifier("processingPipelineJob") JobDetail processingPipelineTask,
-                                     UserProcessingLock userProcessingLock) {
+                                     UserProcessingLock userProcessingLock,
+                                     JobMetadataRepository jobMetadataRepository) {
         this.rawLocationPointJdbcService = rawLocationPointJdbcService;
         this.syntheticPointInserter = syntheticPointInserter;
         this.jobSchedulingService = jobSchedulingService;
         this.processingPipelineTask = processingPipelineTask;
         this.userProcessingLock = userProcessingLock;
+        this.jobMetadataRepository = jobMetadataRepository;
     }
 
     @Override
@@ -47,20 +51,26 @@ public class UpdateCuratedTimelineTask implements Job {
 
     public void execute(TaskData data) {
         log.debug("Starting updating main timeline for user [{}] and device[{}] in timeRange [{}]", data.user, data.device, data.timeRange);
+        UUID jobId = data.getJobId();
         userProcessingLock.locked(data.user, () -> {
             //1. clear main timeline
+            this.jobMetadataRepository.updateProgress(jobId, 0, 4, "Clearing main timeline ...");
             this.rawLocationPointJdbcService.dropForReSeeding(data.user, data.timeRange);
             //2. update main timeline from view
+            this.jobMetadataRepository.updateProgress(jobId, 1, 4, "Updating main timeline ...");
             int updatedCount = this.rawLocationPointJdbcService.updateFromDevices(data.user, data.timeRange);
             log.debug("Updated {} timeline points for user [{}] and device[{}] in timeRange [{}]", updatedCount, data.user, data.device, data.timeRange);
             //3. insert new possible synthetic points
+            this.jobMetadataRepository.updateProgress(jobId, 2, 4, "Inserting synthetic points ...");
             this.syntheticPointInserter.fillGaps(data.user, data.timeRange);
             //4. trigger new processing job
+            this.jobMetadataRepository.updateProgress(jobId, 3, 4, "Scheduling visit detection ...");
             this.jobSchedulingService.enqueueTask(processingPipelineTask,
-                                     new ProcessingPipelineTask.TaskData(data.user.getUsername(), null, null),
+                                     new ProcessingPipelineTask.TaskData(data.user.getUsername(), null, null).withParentJobId(data.getParentJobId()),
                                                   JobSchedulingService.Metadata.builder().jobType(VISIT_TRIP_DETECTION)
                                                           .user(data.user)
                                                           .friendlyName("Detect Visits and Trips").build());
+            this.jobMetadataRepository.updateProgress(jobId, 4, 4, "Done");
         });
 
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -928,6 +928,7 @@ jobs.finishedAt=Finished At:
 jobs.estimated=Estimated Time:
 jobs.actions=Actions
 jobs.childJobs=Child Jobs
+jobs.progress.children={0} / {1} child jobs
 jobs.past.title=Finished Jobs
 jobs.past.empty=No finished jobs yet
 

--- a/src/main/resources/templates/settings/job-status.html
+++ b/src/main/resources/templates/settings/job-status.html
@@ -67,11 +67,16 @@
                                         th:text="#{form.cancel}">Cancel</button>
                             </div>
 
-                            <div class="job-progress">
+                            <div class="job-progress"
+                                 th:if="${job.progressText() != null || job.totalChildren() > 0 || job.progressPercent() > 0}">
                                 <div class="job-progress-bar">
                                     <div class="job-progress-fill" th:title="#{common.percentage(${job.progressPercent()})}" th:style="'width: ' + ${job.progressPercent()} + '%'"></div>
                                 </div>
-                                <div class="job-progress-text" th:text="${job.progressText()}">0 / 0 child jobs</div>
+                                <div class="job-progress-text">
+                                    <th:block th:if="${job.progressText() != null}" th:text="${job.progressText()}">Working...</th:block>
+                                    <th:block th:unless="${job.progressText() != null}"
+                                              th:text="#{jobs.progress.children(${job.completedChildren()}, ${job.totalChildren()})}">0 / 0 child jobs</th:block>
+                                </div>
                             </div>
 
                             <!-- Collapsible child jobs -->
@@ -87,11 +92,11 @@
 
                                             <span class="job-state" th:classappend="${'job-state-' + #strings.toLowerCase(child.state().name())}" th:text="${child.state()}">STATE</span>
                                         </div>
-                                        <div class="job-progress">
+                                        <div class="job-progress" th:if="${child.progressText() != null || child.progressPercent() > 0}">
                                             <div class="job-progress-bar">
                                                 <div class="job-progress-fill" th:title="#{common.percentage(${child.progressPercent()})}" th:style="'width: ' + ${child.progressPercent()} + '%'"></div>
                                             </div>
-                                            <div class="job-progress-text" th:text="${child.progressText()}"></div>
+                                            <div class="job-progress-text" th:if="${child.progressText() != null}" th:text="${child.progressText()}"></div>
                                         </div>
                                     </div>
                                 </div>

--- a/src/test/java/com/dedicatedcode/reitti/controller/settings/JobStatusControllerTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/controller/settings/JobStatusControllerTest.java
@@ -1,0 +1,163 @@
+package com.dedicatedcode.reitti.controller.settings;
+
+import com.dedicatedcode.reitti.IntegrationTest;
+import com.dedicatedcode.reitti.TestingService;
+import com.dedicatedcode.reitti.model.security.User;
+import com.dedicatedcode.reitti.repository.JobMetadataRepository;
+import com.dedicatedcode.reitti.service.JobContext;
+import com.dedicatedcode.reitti.service.jobs.JobSchedulingService;
+import com.dedicatedcode.reitti.service.jobs.JobState;
+import com.dedicatedcode.reitti.service.jobs.JobType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.Scheduler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@IntegrationTest
+class JobStatusControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TestingService testingService;
+
+    @Autowired
+    private JobSchedulingService jobSchedulingService;
+
+    @Autowired
+    private JobMetadataRepository jobMetadataRepository;
+
+    @Autowired
+    private Scheduler scheduler;
+
+    private User admin;
+    private JobDetail noopDetail;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        admin = testingService.admin();
+        noopDetail = JobBuilder.newJob(NoopTask.class)
+                .withIdentity("controller-test-noop-task")
+                .storeDurably()
+                .build();
+        scheduler.addJob(noopDetail, true);
+    }
+
+    @Test
+    void shouldShowPendingParentJob() throws Exception {
+        UUID parentId = jobSchedulingService.createParentJob(admin, JobType.GPX_IMPORT, "controller-test-pending-marker");
+        try {
+            mockMvc.perform(get("/settings/queue-stats-content").with(user(admin)))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(containsString("controller-test-pending-marker")));
+        } finally {
+            jobSchedulingService.cancel(parentId);
+        }
+    }
+
+    @Test
+    void shouldShowFinishedJob() throws Exception {
+        UUID jobId = jobSchedulingService.createParentJob(admin, JobType.GPX_IMPORT, "controller-test-finished-marker");
+        try {
+            jobMetadataRepository.updateState(jobId, JobState.COMPLETED, Instant.now());
+
+            mockMvc.perform(get("/settings/queue-stats-content").with(user(admin)))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(containsString("controller-test-finished-marker")));
+        } finally {
+            jobMetadataRepository.delete(jobId);
+        }
+    }
+
+    @Test
+    void shouldCancelParentAndCascadeChildrenViaEndpoint() throws Exception {
+        UUID parentId = jobSchedulingService.createParentJob(admin, JobType.GPX_IMPORT, "controller-test-cancel-parent");
+
+        UUID child1 = scheduleChild(parentId);
+        UUID child2 = scheduleChild(parentId);
+
+        assertTrue(jobMetadataRepository.findById(child1).isPresent());
+        assertTrue(jobMetadataRepository.findById(child2).isPresent());
+
+        mockMvc.perform(delete("/settings/job/{id}", parentId).with(user(admin)))
+                .andExpect(status().isOk());
+
+        assertFalse(jobMetadataRepository.findById(parentId).isPresent());
+        assertFalse(jobMetadataRepository.findById(child1).isPresent());
+        assertFalse(jobMetadataRepository.findById(child2).isPresent());
+    }
+
+    @Test
+    void shouldHandleCancelOfUnknownJob() throws Exception {
+        mockMvc.perform(delete("/settings/job/{id}", UUID.randomUUID()).with(user(admin)))
+                .andExpect(status().isOk());
+    }
+
+    private UUID scheduleChild(UUID parentId) {
+        List<UUID> before = jobMetadataRepository.findByStates(List.of(JobState.AWAITING)).stream()
+                .map(JobMetadataRepository.JobMetadata::getId)
+                .toList();
+
+        jobSchedulingService.scheduleTask(noopDetail, new NoopTaskData().withParentJobId(parentId),
+                Instant.now().plusSeconds(60),
+                JobSchedulingService.Metadata.builder()
+                        .user(admin)
+                        .jobType(JobType.GPS_IMPORT)
+                        .friendlyName("controller-test-cancel-child")
+                        .build());
+
+        List<UUID> after = jobMetadataRepository.findByStates(List.of(JobState.AWAITING)).stream()
+                .map(JobMetadataRepository.JobMetadata::getId)
+                .toList();
+        assertEquals(before.size() + 1, after.size());
+        return after.stream()
+                .filter(id -> !before.contains(id))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    public static class NoopTaskData extends JobContext<NoopTaskData> {
+        public NoopTaskData() {
+        }
+
+        private NoopTaskData(UUID jobId, UUID parentJobId) {
+            super(jobId, parentJobId);
+        }
+
+        @Override
+        public NoopTaskData withJobId(UUID jobId) {
+            return new NoopTaskData(jobId, parentJobId);
+        }
+
+        @Override
+        public NoopTaskData withParentJobId(UUID parentId) {
+            return new NoopTaskData(jobId, parentId);
+        }
+    }
+
+    public static class NoopTask implements Job {
+        @Override
+        public void execute(JobExecutionContext context) {
+        }
+    }
+}

--- a/src/test/java/com/dedicatedcode/reitti/repository/JobMetadataRepositoryTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/repository/JobMetadataRepositoryTest.java
@@ -1,22 +1,148 @@
 package com.dedicatedcode.reitti.repository;
 
 import com.dedicatedcode.reitti.IntegrationTest;
+import com.dedicatedcode.reitti.TestingService;
+import com.dedicatedcode.reitti.model.security.User;
+import com.dedicatedcode.reitti.service.jobs.JobState;
+import com.dedicatedcode.reitti.service.jobs.JobType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 @IntegrationTest
 class JobMetadataRepositoryTest {
     @Autowired
     private JobMetadataRepository jobMetadataRepository;
 
+    @Autowired
+    private TestingService testingService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        this.user = this.testingService.randomUser();
+    }
+
     @Test
     void shouldReturnEmptyOptional() {
         Optional<JobMetadataRepository.JobMetadata> byId = this.jobMetadataRepository.findById(UUID.randomUUID());
         assertFalse(byId.isPresent());
+    }
+
+    @Test
+    void shouldInsertAndFindJobById() {
+        UUID jobId = UUID.randomUUID();
+        jobMetadataRepository.insert(jobId, user, "test-task", JobType.GPS_IMPORT, "friendly-name", JobState.AWAITING, Instant.now(), Instant.now(), null);
+
+        Optional<JobMetadataRepository.JobMetadata> loaded = jobMetadataRepository.findById(jobId);
+        assertTrue(loaded.isPresent());
+        assertEquals("test-task", loaded.get().getTaskId());
+        assertEquals(JobType.GPS_IMPORT, loaded.get().getJobType());
+        assertEquals("friendly-name", loaded.get().getFriendlyName());
+        assertEquals(JobState.AWAITING, loaded.get().getState());
+        assertEquals(user.getId(), loaded.get().getUserId());
+        assertNull(loaded.get().getParentJobId());
+
+        jobMetadataRepository.delete(jobId);
+        assertFalse(jobMetadataRepository.findById(jobId).isPresent());
+    }
+
+    @Test
+    void shouldFindByStatesIncludingLegacyCreated() {
+        UUID awaitingId = UUID.randomUUID();
+        UUID legacyCreatedId = UUID.randomUUID();
+        jobMetadataRepository.insert(awaitingId, user, "t1", JobType.GPS_IMPORT, "awaiting-job", JobState.AWAITING, Instant.now(), Instant.now(), null);
+        jobMetadataRepository.insert(legacyCreatedId, user, "t2", JobType.GPS_IMPORT, "created-job", JobState.CREATED, Instant.now(), Instant.now(), null);
+
+        List<UUID> foundIds = jobMetadataRepository.findByStates(List.of(JobState.PREPARING, JobState.CREATED, JobState.AWAITING, JobState.RUNNING))
+                .stream()
+                .map(JobMetadataRepository.JobMetadata::getId)
+                .toList();
+
+        assertTrue(foundIds.contains(awaitingId));
+        assertTrue(foundIds.contains(legacyCreatedId));
+
+        jobMetadataRepository.delete(awaitingId);
+        jobMetadataRepository.delete(legacyCreatedId);
+    }
+
+    @Test
+    void shouldDeleteChildrenWhenParentIsDeleted() {
+        UUID parentId = UUID.randomUUID();
+        UUID childA = UUID.randomUUID();
+        UUID childB = UUID.randomUUID();
+
+        jobMetadataRepository.insert(parentId, user, null, JobType.GPX_IMPORT, "parent", JobState.AWAITING, Instant.now(), Instant.now(), null);
+        jobMetadataRepository.insert(childA, user, "child-a", JobType.GPX_IMPORT, "child-a", JobState.AWAITING, Instant.now(), Instant.now(), parentId);
+        jobMetadataRepository.insert(childB, user, "child-b", JobType.GPX_IMPORT, "child-b", JobState.AWAITING, Instant.now(), Instant.now(), parentId);
+
+        assertEquals(2, jobMetadataRepository.findByParentJobId(parentId).size());
+
+        jobMetadataRepository.delete(parentId);
+
+        assertFalse(jobMetadataRepository.findById(parentId).isPresent());
+        assertFalse(jobMetadataRepository.findById(childA).isPresent());
+        assertFalse(jobMetadataRepository.findById(childB).isPresent());
+    }
+
+    @Test
+    void shouldPropagateRunningStateToParent() {
+        UUID parentId = UUID.randomUUID();
+        UUID childId = UUID.randomUUID();
+
+        jobMetadataRepository.insert(parentId, user, null, JobType.GPX_IMPORT, "parent", JobState.AWAITING, Instant.now(), Instant.now(), null);
+        jobMetadataRepository.insert(childId, user, "child", JobType.GPX_IMPORT, "child", JobState.AWAITING, Instant.now(), Instant.now(), parentId);
+
+        jobMetadataRepository.updateState(childId, JobState.RUNNING, Instant.now());
+        jobMetadataRepository.updateParentJobState(parentId, JobState.RUNNING);
+        assertEquals(JobState.RUNNING, jobMetadataRepository.findById(parentId).orElseThrow().getState());
+
+        jobMetadataRepository.delete(parentId);
+    }
+
+    @Test
+    void shouldCompleteParentOnlyWhenAllChildrenAreTerminal() {
+        UUID parentId = UUID.randomUUID();
+        UUID childA = UUID.randomUUID();
+        UUID childB = UUID.randomUUID();
+
+        jobMetadataRepository.insert(parentId, user, null, JobType.GPX_IMPORT, "parent", JobState.RUNNING, Instant.now(), Instant.now(), null);
+        jobMetadataRepository.insert(childA, user, "child-a", JobType.GPX_IMPORT, "child-a", JobState.RUNNING, Instant.now(), Instant.now(), parentId);
+        jobMetadataRepository.insert(childB, user, "child-b", JobType.GPX_IMPORT, "child-b", JobState.RUNNING, Instant.now(), Instant.now(), parentId);
+
+        // first child finishes -> parent must stay RUNNING
+        jobMetadataRepository.updateState(childA, JobState.COMPLETED, Instant.now());
+        jobMetadataRepository.updateParentJobState(parentId, JobState.COMPLETED);
+        assertEquals(JobState.RUNNING, jobMetadataRepository.findById(parentId).orElseThrow().getState());
+
+        // second child fails -> parent must become FAILED
+        jobMetadataRepository.updateState(childB, JobState.FAILED, Instant.now());
+        jobMetadataRepository.updateParentJobState(parentId, JobState.COMPLETED);
+        assertEquals(JobState.FAILED, jobMetadataRepository.findById(parentId).orElseThrow().getState());
+
+        jobMetadataRepository.delete(parentId);
+    }
+
+    @Test
+    void shouldStoreAndReadProgress() {
+        UUID jobId = UUID.randomUUID();
+        jobMetadataRepository.insert(jobId, user, "task", JobType.REVERSE_GEOCODE, "geo", JobState.RUNNING, Instant.now(), Instant.now(), null);
+
+        jobMetadataRepository.updateProgress(jobId, 7, 10, "working");
+
+        JobMetadataRepository.JobMetadata loaded = jobMetadataRepository.findById(jobId).orElseThrow();
+        assertEquals(7L, loaded.getCurrentProgress());
+        assertEquals(10L, loaded.getMaxProgress());
+        assertEquals("working", loaded.getProgressMessage());
+
+        jobMetadataRepository.delete(jobId);
     }
 }

--- a/src/test/java/com/dedicatedcode/reitti/service/jobs/JobChainParentPropagationTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/jobs/JobChainParentPropagationTest.java
@@ -1,0 +1,82 @@
+package com.dedicatedcode.reitti.service.jobs;
+
+import com.dedicatedcode.reitti.IntegrationTest;
+import com.dedicatedcode.reitti.TestingService;
+import com.dedicatedcode.reitti.model.devices.Device;
+import com.dedicatedcode.reitti.model.security.User;
+import com.dedicatedcode.reitti.repository.JobMetadataRepository;
+import com.dedicatedcode.reitti.service.processing.LocationDataCleanupTask;
+import com.dedicatedcode.reitti.service.processing.PatchDeviceOntoTimelineTask;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@IntegrationTest
+class JobChainParentPropagationTest {
+
+    @Autowired
+    private PatchDeviceOntoTimelineTask patchDeviceOntoTimelineTask;
+
+    @Autowired
+    private LocationDataCleanupTask locationDataCleanupTask;
+
+    @Autowired
+    private JobSchedulingService jobSchedulingService;
+
+    @Autowired
+    private JobMetadataRepository jobMetadataRepository;
+
+    @Autowired
+    private TestingService testingService;
+
+    @Test
+    void patchDeviceShouldFlattenSuccessorsUnderTheSameParent() {
+        User user = testingService.randomUser();
+        Device device = testingService.findDefaultDevice(user);
+        UUID parentId = jobSchedulingService.createParentJob(user, JobType.MANUAL_MODIFICATION, "chain-test-patch-parent");
+        try {
+            patchDeviceOntoTimelineTask.execute(new PatchDeviceOntoTimelineTask.TaskData(user, device,
+                    Instant.now().minusSeconds(3600), Instant.now()).withParentJobId(parentId));
+
+            // timeline stitching and the following visit detection must both become siblings
+            // under the same parent instead of being nested below the patch task
+            await().atMost(30, TimeUnit.SECONDS).until(() -> {
+                List<JobMetadataRepository.JobMetadata> children = jobMetadataRepository.findByParentJobId(parentId);
+                return children.stream().anyMatch(j -> j.getJobType() == JobType.TIMELINE_STITCHING)
+                        && children.stream().anyMatch(j -> j.getJobType() == JobType.VISIT_TRIP_DETECTION);
+            });
+
+            // the stitching task itself must not have spawned its own children
+            JobMetadataRepository.JobMetadata stitchingRow = jobMetadataRepository.findByParentJobId(parentId).stream()
+                    .filter(j -> j.getJobType() == JobType.TIMELINE_STITCHING)
+                    .findFirst()
+                    .orElseThrow();
+            assertEquals(List.of(), jobMetadataRepository.findByParentJobId(stitchingRow.getId()));
+        } finally {
+            jobSchedulingService.cancel(parentId);
+        }
+    }
+
+    @Test
+    void locationDataCleanupShouldFlattenSuccessorsUnderTheSameParent() {
+        User user = testingService.randomUser();
+        Device device = testingService.findDefaultDevice(user);
+        UUID parentId = jobSchedulingService.createParentJob(user, JobType.LOCATION_DATA_CLEANUP, "chain-test-cleanup-parent");
+        try {
+            locationDataCleanupTask.execute(new LocationDataCleanupTask.TaskData(user, device,
+                    Instant.now().minusSeconds(7200), Instant.now().minusSeconds(3600)).withParentJobId(parentId));
+
+            await().atMost(30, TimeUnit.SECONDS).until(() -> jobMetadataRepository.findByParentJobId(parentId).stream()
+                    .anyMatch(j -> j.getJobType() == JobType.VISIT_TRIP_DETECTION));
+        } finally {
+            jobSchedulingService.cancel(parentId);
+        }
+    }
+}

--- a/src/test/java/com/dedicatedcode/reitti/service/jobs/JobSchedulingServiceIntegrationTest.java
+++ b/src/test/java/com/dedicatedcode/reitti/service/jobs/JobSchedulingServiceIntegrationTest.java
@@ -1,0 +1,229 @@
+package com.dedicatedcode.reitti.service.jobs;
+
+import com.dedicatedcode.reitti.IntegrationTest;
+import com.dedicatedcode.reitti.TestingService;
+import com.dedicatedcode.reitti.model.security.User;
+import com.dedicatedcode.reitti.repository.JobMetadataRepository;
+import com.dedicatedcode.reitti.service.JobContext;
+import org.junit.jupiter.api.Test;
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.Scheduler;
+import org.quartz.TriggerKey;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.*;
+
+@IntegrationTest
+class JobSchedulingServiceIntegrationTest {
+
+    @Autowired
+    private JobSchedulingService jobSchedulingService;
+
+    @Autowired
+    private JobMetadataRepository jobMetadataRepository;
+
+    @Autowired
+    private Scheduler scheduler;
+
+    @Autowired
+    private TestingService testingService;
+
+    private static TriggerKey taskTriggerKey(UUID jobId) {
+        return TriggerKey.triggerKey(jobId.toString(), JobSchedulingService.TASK_TRIGGER_GROUP);
+    }
+
+    @Test
+    void shouldScheduleTaskAsAwaitingAndCompleteIt() throws Exception {
+        RecordingTask.executions.clear();
+        JobDetail detail = JobBuilder.newJob(RecordingTask.class)
+                .withIdentity("integration-test-recording-task")
+                .storeDurably()
+                .build();
+        scheduler.addJob(detail, true);
+
+        jobSchedulingService.enqueueTask(detail, new TaskData(), JobSchedulingService.Metadata.builder()
+                .user(testingService.randomUser())
+                .jobType(JobType.GPS_IMPORT)
+                .friendlyName("integration-test-recording")
+                .build());
+
+        await().atMost(10, TimeUnit.SECONDS).until(() -> !RecordingTask.executions.isEmpty());
+        UUID jobId = RecordingTask.executions.keySet().iterator().next();
+
+        await().atMost(10, TimeUnit.SECONDS)
+                .until(() -> jobMetadataRepository.getState(jobId).orElse(null) == JobState.COMPLETED);
+
+        JobMetadataRepository.JobMetadata metadata = jobMetadataRepository.findById(jobId).orElseThrow();
+        assertEquals(JobType.GPS_IMPORT, metadata.getJobType());
+        assertFalse(scheduler.checkExists(taskTriggerKey(jobId)));
+
+        jobMetadataRepository.delete(jobId);
+    }
+
+    @Test
+    void shouldBeVisibleWhileScheduledInTheFuture() throws Exception {
+        JobDetail detail = JobBuilder.newJob(RecordingTask.class)
+                .withIdentity("integration-test-future-task")
+                .storeDurably()
+                .build();
+        scheduler.addJob(detail, true);
+
+        jobSchedulingService.scheduleTask(detail, new TaskData(), Instant.now().plusSeconds(30), JobSchedulingService.Metadata.builder()
+                .user(testingService.randomUser())
+                .jobType(JobType.GPS_IMPORT)
+                .friendlyName("integration-test-future")
+                .build());
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> jobMetadataRepository.findByStates(List.of(JobState.AWAITING)).stream()
+                        .anyMatch(j -> "integration-test-future".equals(j.getFriendlyName())));
+
+        for (JobMetadataRepository.JobMetadata job : jobMetadataRepository.findByStates(List.of(JobState.AWAITING))) {
+            if ("integration-test-future".equals(job.getFriendlyName())) {
+                jobSchedulingService.cancel(job.getId());
+                assertTrue(jobMetadataRepository.findById(job.getId()).isEmpty());
+                assertFalse(scheduler.checkExists(taskTriggerKey(job.getId())));
+            }
+        }
+    }
+
+    @Test
+    void shouldDeferWithoutCreatingNewMetadata() throws Exception {
+        DeferringOnceTask.executions.clear();
+        User user = testingService.randomUser();
+        JobDetail detail = JobBuilder.newJob(DeferringOnceTask.class)
+                .withIdentity("integration-test-defer-task")
+                .storeDurably()
+                .build();
+        scheduler.addJob(detail, true);
+
+        jobSchedulingService.enqueueTask(detail, new TaskData(), JobSchedulingService.Metadata.builder()
+                .user(user)
+                .jobType(JobType.H3_CELL_UPDATE)
+                .friendlyName("integration-test-defer")
+                .build());
+
+        await().atMost(10, TimeUnit.SECONDS).until(() -> !DeferringOnceTask.executions.isEmpty());
+        UUID jobId = DeferringOnceTask.executions.keySet().iterator().next();
+
+        await().atMost(10, TimeUnit.SECONDS)
+                .until(() -> jobMetadataRepository.getState(jobId).orElse(null) == JobState.COMPLETED);
+
+        assertEquals(2, DeferringOnceTask.executions.get(jobId));
+        assertTrue(jobMetadataRepository.findByParentJobId(jobId).isEmpty());
+
+        List<JobMetadataRepository.JobMetadata> rowsForJob = jobMetadataRepository.findByStates(List.of(JobState.COMPLETED)).stream()
+                .filter(j -> jobId.equals(j.getId()))
+                .toList();
+        assertEquals(1, rowsForJob.size());
+        assertEquals("test defer", rowsForJob.getFirst().getProgressMessage());
+
+        assertFalse(scheduler.checkExists(taskTriggerKey(jobId)));
+        Set<org.quartz.TriggerKey> leftover = scheduler.getTriggerKeys(
+                org.quartz.impl.matchers.GroupMatcher.triggerGroupEquals(JobSchedulingService.TASK_TRIGGER_GROUP));
+        assertTrue(leftover.stream().noneMatch(k -> k.getName().startsWith(jobId.toString())));
+
+        jobMetadataRepository.delete(jobId);
+    }
+
+    @Test
+    void shouldCancelParentAndRemoveChildTriggers() throws Exception {
+        User user = testingService.randomUser();
+        UUID parentId = jobSchedulingService.createParentJob(user, JobType.GPX_IMPORT, "integration-test-parent");
+
+        JobDetail detail = JobBuilder.newJob(RecordingTask.class)
+                .withIdentity("integration-test-cancel-task")
+                .storeDurably()
+                .build();
+        scheduler.addJob(detail, true);
+
+        jobSchedulingService.scheduleTask(detail, new TaskData().withParentJobId(parentId), Instant.now().plusSeconds(60), JobSchedulingService.Metadata.builder()
+                .user(user)
+                .jobType(JobType.GPS_IMPORT)
+                .friendlyName("integration-test-child-1")
+                .build());
+        jobSchedulingService.scheduleTask(detail, new TaskData().withParentJobId(parentId), Instant.now().plusSeconds(60), JobSchedulingService.Metadata.builder()
+                .user(user)
+                .jobType(JobType.GPS_IMPORT)
+                .friendlyName("integration-test-child-2")
+                .build());
+
+        List<UUID> childIds = jobMetadataRepository.findByParentJobId(parentId).stream()
+                .map(JobMetadataRepository.JobMetadata::getId)
+                .toList();
+        assertEquals(2, childIds.size());
+
+        for (UUID childId : childIds) {
+            assertTrue(scheduler.checkExists(taskTriggerKey(childId)));
+        }
+
+        jobSchedulingService.cancel(parentId);
+
+        assertTrue(jobMetadataRepository.findById(parentId).isEmpty());
+        assertTrue(jobMetadataRepository.findByParentJobId(parentId).isEmpty());
+        for (UUID childId : childIds) {
+            assertFalse(scheduler.checkExists(taskTriggerKey(childId)));
+        }
+    }
+
+    public static class TaskData extends JobContext<TaskData> {
+        public TaskData() {
+        }
+
+        private TaskData(UUID jobId, UUID parentJobId) {
+            super(jobId, parentJobId);
+        }
+
+        @Override
+        public TaskData withJobId(UUID jobId) {
+            return new TaskData(jobId, parentJobId);
+        }
+
+        @Override
+        public TaskData withParentJobId(UUID parentId) {
+            return new TaskData(jobId, parentId);
+        }
+    }
+
+    public static class RecordingTask implements Job {
+        static final Map<UUID, Integer> executions = new ConcurrentHashMap<>();
+
+        @Override
+        public void execute(JobExecutionContext context) {
+            UUID jobId = UUID.fromString(context.getMergedJobDataMap().getString("jobId"));
+            executions.merge(jobId, 1, Integer::sum);
+        }
+    }
+
+    public static class DeferringOnceTask implements Job {
+        static final Map<UUID, Integer> executions = new ConcurrentHashMap<>();
+
+        @Autowired
+        private JobSchedulingService jobSchedulingService;
+
+        @Override
+        public void execute(JobExecutionContext context) {
+            UUID jobId = UUID.fromString(context.getMergedJobDataMap().getString("jobId"));
+            int run = executions.merge(jobId, 1, Integer::sum);
+            if (run == 1) {
+                boolean deferred = jobSchedulingService.defer(context, Duration.ofMillis(250), "test defer");
+                if (!deferred) {
+                    throw new IllegalStateException("expected job to be deferrable");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Refactor H3CellUpdateJob to enhance rescheduling and progress updates
- Add progress tracking for UpdateCuratedTimelineTask and DataCleanupService
- Remove unused `verifyAgainstQuartz` method in JobMetadataRepository
- Simplify `JobInfo` construction logic in JobStatusController
- Add tests for JobStatusController and JobSchedulingService behaviors