### PR TITLE
feature(#1236) Harden GPSLogger auto-configuration

### DIFF
--- a/src/main/java/com/dedicatedcode/reitti/controller/settings/IntegrationsSettingsController.java
+++ b/src/main/java/com/dedicatedcode/reitti/controller/settings/IntegrationsSettingsController.java
@@ -164,6 +164,7 @@ public class IntegrationsSettingsController {
         String url = serverUrl + contextPathHolder.getContextPath() + "/api/v2/gpslogger/file";
         String properties = "httpfileupload_url=" + url + "\n" +
                 "httpfileupload_method=POST\n" +
+                "autosend_sendzip=false\n" +
                 "autohttpfileupload_enabled=true\n" +
                 "httpfileupload_basicauth_password=\n" +
                 "httpfileupload_body_type=form-data\n" +


### PR DESCRIPTION
- Add `autosend_sendzip=false` to GPSLogger integration settings